### PR TITLE
Make sure daily 'at_time' jobs are run on the first day

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 History
 -------
 
+0.2.0 (unreleased)
+++++++++++++++++++
+
+- Fixed issue with 'at_time' jobs not running on the same day the job is created
+
 0.1.9 (2013-05-27)
 ++++++++++++++++++
 

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -232,6 +232,11 @@ class Job(object):
                                                   minute=self.at_time.minute,
                                                   second=self.at_time.second,
                                                   microsecond=0)
+            # if we are running for the first time,
+            # make sure we run at the specified time *today* as well
+            if not self.last_run \
+                    and self.at_time > datetime.datetime.now().time():
+                self.next_run = self.next_run - datetime.timedelta(days=1)
 
 
 # The following methods are shortcuts for not having to

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -58,6 +58,8 @@ class SchedulerTests(unittest.TestCase):
         assert every(5).minutes.do(mock_job).next_run.minute == 20
         assert every().hour.do(mock_job).next_run.hour == 13
         assert every().day.do(mock_job).next_run.day == 7
+        assert every().day.at('09:00').do(mock_job).next_run.day == 7
+        assert every().day.at('12:30').do(mock_job).next_run.day == 6
         assert every().week.do(mock_job).next_run.day == 13
 
         datetime.datetime = original_datetime


### PR DESCRIPTION
Resolved an issue where daily at_time jobs are not run until the day _after_ the job is added, even if the 'at_time' has not yet passed when the job is added.
