### PR TITLE
Add support for random intervals

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,7 @@ Usage
     schedule.every(10).minutes.do(job)
     schedule.every().hour.do(job)
     schedule.every().day.at("10:30").do(job)
+    schedule.every(5).to(10).days.do(job)
     schedule.every().monday.do(job)
     schedule.every().wednesday.at("13:15").do(job)
 

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -314,6 +314,7 @@ class Job(object):
         assert self.unit in ('seconds', 'minutes', 'hours', 'days', 'weeks')
 
         if self.latest is not None:
+            assert self.latest >= self.interval
             interval = random.randint(self.interval, self.latest)
         else:
             interval = self.interval

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -72,7 +72,7 @@ class SchedulerTests(unittest.TestCase):
             # same value will be chosen each time.
             minutes = set([
                 every(5).to(30).minutes.do(mock_job).next_run.minute
-                for i in xrange(100)
+                for i in range(100)
             ])
 
             assert len(minutes) > 1

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -70,14 +70,14 @@ class SchedulerTests(unittest.TestCase):
 
             # Choose a sample size large enough that it's unlikely the
             # same value will be chosen each time.
-            intervals = set([
-                every(1).to(10).minutes.do(mock_job).next_run.minute
+            minutes = set([
+                every(5).to(30).minutes.do(mock_job).next_run.minute
                 for i in xrange(100)
             ])
 
-            assert len(intervals) > 1
-            assert min(intervals) >= 1
-            assert max(intervals) <= 10
+            assert len(minutes) > 1
+            assert min(minutes) >= 5
+            assert max(minutes) <= 30
 
     def test_at_time(self):
         mock_job = make_mock_job()

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -64,6 +64,21 @@ class SchedulerTests(unittest.TestCase):
         assert every().day.unit == every().days.unit
         assert every().week.unit == every().weeks.unit
 
+    def test_time_range(self):
+        with mock_datetime(2014, 6, 28, 12, 0):
+            mock_job = make_mock_job()
+
+            # Choose a sample size large enough that it's unlikely the
+            # same value will be chosen each time.
+            intervals = set([
+                every(1).to(10).minutes.do(mock_job).next_run.minute
+                for i in xrange(100)
+            ])
+
+            assert len(intervals) > 1
+            assert min(intervals) >= 1
+            assert max(intervals) <= 10
+
     def test_at_time(self):
         mock_job = make_mock_job()
         assert every().day.at('10:30').do(mock_job).next_run.hour == 10


### PR DESCRIPTION
For tasks that should run at an irregular interval, this adds the following syntax:

``` python
schedule.every(10).to(20).hours.do(job)
```

The scheduler picks a random value in that range as the actual interval used when scheduling the next run.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dbader/schedule/26)

<!-- Reviewable:end -->
