### PR TITLE
Feature: limitate number of call performed for one job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ nosetests.xml
 # Translations
 *.mo
 
+# vim
+.*.swp
+.*.swo
+
 # Mr Developer
 .mr.developer.cfg
 .project

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,7 @@ Usage
     schedule.every().day.at("10:30").do(job)
     schedule.every().monday.do(job)
     schedule.every().wednesday.at("13:15").do(job)
+    schedule.every().wednesday.at("13:15").do(job).at_most(4)
 
     while True:
         schedule.run_pending()


### PR DESCRIPTION
A job can be cancelled after a precise number of calls.
All existings tox tests are ok. No new test, except one doctest in _schedule/__init__.py_

```
# print text every seconds at most 5 times :
schedule.every().seconds.do(lambda : print('hello')).at_most(5)
```

Currently, the method identificator Job.at_most() is not so readable. Ideas ?
Can Job.is_cancelled() method be used for detect other cases of cancellation ?
