### PR TITLE
Scheduling a job to run every >= 2 days causes the initial execution to happen one day early

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -322,7 +322,7 @@ class Job(object):
             # at the specified time *today* (or *this hour*) as well
             if not self.last_run:
                 now = datetime.datetime.now()
-                if self.unit == 'days' and self.at_time > now.time():
+                if self.unit == 'days' and self.at_time > now.time() and self.interval == 1:
                     self.next_run = self.next_run - datetime.timedelta(days=1)
                 elif self.unit == 'hours' and self.at_time.minute > now.minute:
                     self.next_run = self.next_run - datetime.timedelta(hours=1)

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -322,7 +322,8 @@ class Job(object):
             # at the specified time *today* (or *this hour*) as well
             if not self.last_run:
                 now = datetime.datetime.now()
-                if self.unit == 'days' and self.at_time > now.time() and self.interval == 1:
+                if (self.unit == 'days' and self.at_time > now.time() and
+                        self.interval == 1):
                     self.next_run = self.next_run - datetime.timedelta(days=1)
                 elif self.unit == 'hours' and self.at_time.minute > now.minute:
                     self.next_run = self.next_run - datetime.timedelta(hours=1)

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -189,8 +189,12 @@ class SchedulerTests(unittest.TestCase):
 
     def test_run_every_n_days_at_specific_time(self):
         mock_job = make_mock_job()
-        with mock_datetime(2010, 1, 6, 13, 16):
+        with mock_datetime(2010, 1, 6, 11, 16):
             every(2).days.at("11:30").do(mock_job)
+            schedule.run_pending()
+            assert mock_job.call_count == 0
+
+        with mock_datetime(2010, 1, 6, 13, 16):
             schedule.run_pending()
             assert mock_job.call_count == 0
 


### PR DESCRIPTION
when creating a new job every(N).at(X) with N > 1 and the current time is lower than X, the scheduler will schedule the job 1 day before the next expected run