### PR TITLE
AttributeError scheduling functools.partial objects

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -134,11 +134,14 @@ class Job(object):
         timestats = '(last run: %s, next run: %s)' % (
                     format_time(self.last_run), format_time(self.next_run))
 
-        job_func_name = self.job_func.__name__
-        args = [repr(x) for x in self.job_func.args]
-        kwargs = ['%s=%s' % (k, repr(v))
-                  for k, v in self.job_func.keywords.items()]
-        call_repr = job_func_name + '(' + ', '.join(args + kwargs) + ')'
+        try:
+            job_func_name = self.job_func.__name__
+            args = [repr(x) for x in self.job_func.args]
+            kwargs = ['%s=%s' % (k, repr(v))
+                      for k, v in self.job_func.keywords.items()]
+            call_repr = job_func_name + '(' + ', '.join(args + kwargs) + ')'
+        except AttributeError:
+            call_repr = repr(self.job_func)
 
         if self.at_time is not None:
             return 'Every %s %s at %s do %s %s' % (

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -121,6 +121,14 @@ class SchedulerTests(unittest.TestCase):
         assert len(str(every().minute.do(lambda: 1))) > 1
         assert len(str(every().day.at("10:30").do(lambda: 1))) > 1
 
+    def test_functools_jobs_repr(self):
+        import functools
+        def job_fun(arg):
+            pass
+        job_fun = functools.partial(job_fun, 'foo')
+        r = repr(every().minute.do(job_fun))
+        assert r == repr(job_fun)
+
     def test_run_pending(self):
         """Check that run_pending() runs pending jobs.
         We do this by overriding datetime.datetime with mock objects


### PR DESCRIPTION
When scheduling a job with a functools.partial as the job function, an AttributeError is thrown trying to create the repr for the job. How to reproduce:

    import schedule
    import functools
    def test(text):
        print(text)
    func = functools.partial(test, "Test")
    schedule.every().second.do(func)

This results in:

    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/usr/lib/python3.4/site-packages/schedule/__init__.py", line 137, in __repr
    __
        job_func_name = self.job_func.__name__
    AttributeError: 'functools.partial' object has no attribute '__name__'

This pull request fixes this issue by wrapping the whole creation of call_repr in try/except, and just using repr(job_func) if an exception occurs. This will prevent this error if job_func lacks __name__, args, or keywords.