### PR TITLE
Restrict resolution to seconds when running pending tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ lib64
 pip-log.txt
 
 # Unit test / coverage reports
+.cache
 .coverage
 .tox
 nosetests.xml

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -285,7 +285,8 @@ class Job(object):
     @property
     def should_run(self):
         """True if the job should be run now."""
-        return datetime.datetime.now() >= self.next_run
+        return ((datetime.datetime.now() >= self.next_run) or
+                (self.next_run - datetime.datetime.now()).total_seconds() < 1)
 
     def run(self):
         """Run the job and immediately reschedule it."""

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -22,12 +22,15 @@ class mock_datetime(object):
     """
     Monkey-patch datetime for predictable results
     """
-    def __init__(self, year, month, day, hour, minute):
+    def __init__(self, year, month, day, hour, minute,
+                 seconds=0, microseconds=0):
         self.year = year
         self.month = month
         self.day = day
         self.hour = hour
         self.minute = minute
+        self.seconds = seconds
+        self.microseconds = microseconds
 
     def __enter__(self):
         class MockDate(datetime.datetime):
@@ -38,7 +41,8 @@ class mock_datetime(object):
             @classmethod
             def now(cls):
                 return cls(self.year, self.month, self.day,
-                           self.hour, self.minute)
+                           self.hour, self.minute, self.seconds,
+                           self.microseconds)
         self.original_datetime = datetime.datetime
         datetime.datetime = MockDate
 
@@ -155,6 +159,11 @@ class SchedulerTests(unittest.TestCase):
             assert mock_job.call_count == 0
 
         with mock_datetime(2010, 1, 6, 12, 16):
+            schedule.run_pending()
+            assert mock_job.call_count == 1
+
+        with mock_datetime(2010, 1, 6, 12, 16, 59, 999999):
+            mock_job.reset_mock()
             schedule.run_pending()
             assert mock_job.call_count == 1
 


### PR DESCRIPTION
schedule's current resolution is seconds. This changeset runs the pending tasks within a resolution of second to be most effective.

Consider the below scenario:
* Job is setup to run every second
* Current datetime is 10:00:00
* Now if the next run_pending is called at 10:00:59.999999, we miss running the job
* Even if the callee is calling run_pending every 1 seconds, it's possible that his job will run at 10:00:01.999999.
* This is not just about first run, but there could be many such scenarios depending upon when run_pending is called.
