### PR TITLE
Feature: schedule_every function decorator.

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -394,3 +394,76 @@ def next_run():
 def idle_seconds():
     """Number of seconds until `next_run`."""
     return default_scheduler.idle_seconds
+
+def schedule_every(unit,interval=1,at=None):
+    """Function decorator for schedule.every."""
+    def _schedule(function):
+        if 'second' in unit:
+            #plural
+            if unit[-1] == 's':
+                if at:
+                    every(interval).seconds.at(at).do(function)
+                else:
+                    every(interval).seconds.do(function)
+            #singular
+            else:
+                if at:
+                    every().second.at(at).do(function)
+                else:
+                    every().second.do(function)
+        if 'minute' in unit:
+            #plural
+            if unit[-1] == 's':
+                if at:
+                    every(interval).minutes.at(at).do(function)
+                else:
+                    every(interval).minutes.do(function)
+            #singular
+            else:
+                if at:
+                    every().minute.at(at).do(function)
+                else:
+                    every().minute.do(function)
+            
+        if 'hour' in unit:
+            #plural
+            if unit[-1] == 's':
+                if at:
+                    every(interval).hours.at(at).do(function)
+                else:
+                    every(interval).hours.do(function)
+            #singular
+            else:
+                if at:
+                    every().hour.at(at).do(function)
+                else:
+                    every().hour.do(function)
+            
+        if 'day' in unit:
+            #plural
+            if unit[-1] == 's':
+                if at:
+                    every(interval).days.at(at).do(function)
+                else:
+                    every(interval).days.do(function)
+            #singular
+            else:
+                if at:
+                    every().day.at(at).do(function)
+                else:
+                    every().day.do(function)
+                      
+        if 'week' in unit:
+            #plural
+            if unit[-1] == 's':
+                if at:
+                    every(interval).weeks.at(at).do(function)
+                else:
+                    every(interval).weeks.do(function)
+            #singular
+            else:
+                if at:
+                    every().week.at(at).do(function)
+                else:
+                    every().week.do(function)
+    return _schedule

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -395,72 +395,62 @@ def idle_seconds():
     """Number of seconds until `next_run`."""
     return default_scheduler.idle_seconds
 
-def schedule_every(unit,interval=1,at=None):
+
+def schedule_every(unit, interval=1, at=None):
     """Function decorator for schedule.every."""
     def _schedule(function):
         if 'second' in unit:
-            #plural
+            # plural
             if unit[-1] == 's':
                 if at:
                     every(interval).seconds.at(at).do(function)
                 else:
                     every(interval).seconds.do(function)
-            #singular
+            # singular
             else:
                 if at:
                     every().second.at(at).do(function)
                 else:
                     every().second.do(function)
         if 'minute' in unit:
-            #plural
             if unit[-1] == 's':
                 if at:
                     every(interval).minutes.at(at).do(function)
                 else:
                     every(interval).minutes.do(function)
-            #singular
             else:
                 if at:
                     every().minute.at(at).do(function)
                 else:
                     every().minute.do(function)
-            
         if 'hour' in unit:
-            #plural
             if unit[-1] == 's':
                 if at:
                     every(interval).hours.at(at).do(function)
                 else:
                     every(interval).hours.do(function)
-            #singular
             else:
                 if at:
                     every().hour.at(at).do(function)
                 else:
                     every().hour.do(function)
-            
         if 'day' in unit:
-            #plural
             if unit[-1] == 's':
                 if at:
                     every(interval).days.at(at).do(function)
                 else:
                     every(interval).days.do(function)
-            #singular
             else:
                 if at:
                     every().day.at(at).do(function)
                 else:
                     every().day.do(function)
-                      
         if 'week' in unit:
-            #plural
             if unit[-1] == 's':
                 if at:
                     every(interval).weeks.at(at).do(function)
                 else:
                     every(interval).weeks.do(function)
-            #singular
             else:
                 if at:
                     every().week.at(at).do(function)


### PR DESCRIPTION
Implements the decorator requested in issue #60. While it doesn't follow the requested syntax, I don't think it's entirely hideous:

```
import schedule
from schedule import schedule_every
@schedule_every('seconds',3)
def job():
    print('I'm working...')
```

You can also pass in `at`:

```
@schedule_every('hours',interval=3,"12:00")
def job():
    print('I'm working...')
```
