### PR TITLE
Wrap the call to job_func() in try/except

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -290,7 +290,11 @@ class Job(object):
     def run(self):
         """Run the job and immediately reschedule it."""
         logger.info('Running job %s', self)
-        ret = self.job_func()
+        ret = None
+        try:
+            ret = self.job_func()
+        except:
+            logger.exception('Job %s Died Unexpectedly', self)
         self.last_run = datetime.datetime.now()
         self._schedule_next_run()
         return ret


### PR DESCRIPTION
Wrap calling job_func() in a try/except. 

Previously if job_func() threw an exception the job would never be rescheduled and would end up causing the entire call to run_pending() to bomb out. This prevents that and allows for failed jobs to be rescheduled.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dbader/schedule/77)

<!-- Reviewable:end -->
