### PR TITLE
CI build improvements (Py 3.5, flake8, dev requirements)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ develop-eggs
 .installed.cfg
 lib
 lib64
+MANIFEST
 
 # Installer logs
 pip-log.txt
@@ -37,3 +38,6 @@ nosetests.xml
 env
 env3
 __pycache__
+venv
+
+.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,8 @@
+sudo: false
 language: python
-
 python:
     - "2.7"
     - "3.5"
-
-install:
-    - pip install -r requirements-dev.txt --use-mirrors
-
-script:
-    - py.test test_schedule.py --flake8 schedule -v --cov schedule --cov-report term-missing
-    - python setup.py check --strict --metadata --restructuredtext
-
-after_success:
-    - coveralls
+install: pip install tox-travis
+script: tox
+after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 python:
     - "2.7"
-    - "3.3"
+    - "3.5"
 
 install:
     - pip install pytest-cov --use-mirrors

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
     - pip install -r requirements-dev.txt --use-mirrors
 
 script:
-    - py.test test_schedule.py --pep8 schedule -v --cov schedule --cov-report term-missing
+    - py.test test_schedule.py --flake8 schedule -v --cov schedule --cov-report term-missing
     - python setup.py check --strict --metadata --restructuredtext
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ install:
     - pip install pytest-pep8 --use-mirrors
     - pip install coveralls --use-mirrors
 
-script: py.test test_schedule.py --pep8 schedule -v --cov schedule --cov-report term-missing
+script:
+    - py.test test_schedule.py --pep8 schedule -v --cov schedule --cov-report term-missing
+    - python setup.py check
 
 after_success:
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,11 @@ python:
     - "3.5"
 
 install:
-    - pip install pytest-cov --use-mirrors
-    - pip install pytest-pep8 --use-mirrors
-    - pip install coveralls --use-mirrors
+    - pip install -r requirements-dev.txt --use-mirrors
 
 script:
     - py.test test_schedule.py --pep8 schedule -v --cov schedule --cov-report term-missing
-    - python setup.py check
+    - python setup.py check --strict --metadata --restructuredtext
 
 after_success:
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: python
 python:
-    - "2.7"
+    - "2.7.11"
     - "3.5"
 install: pip install tox-travis
 script: tox

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Features
 - A simple to use API for scheduling jobs.
 - Very lightweight and no external dependencies.
 - Excellent test coverage.
-- Tested on Python 2.7 and 3.4
+- Tested on Python 2.7 and 3.5
 
 Usage
 -----

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
-mock==1.3.0
-pytest==2.8.7
-pytest-cov==1.8.1
-pytest-flake8==0.1
-docutils
-pygments
+docutils==0.12
+mock==2.0.0
+Pygments==2.1.3
+pytest==3.0.3
+pytest-cov==2.4.0
+pytest-flake8==0.8.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+mock==1.3.0
+pytest==2.8.7
+pytest-cov==1.8.1
+pytest-flake8==0.1
+docutils
+pygments

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34
+envlist = py27, py35
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,7 @@
 envlist = py27, py35
 
 [testenv]
-deps =
-    mock
-    pytest
-    pytest-cov
-    pytest-pep8
+deps = -rrequirements-dev.txt
 commands =
-    py.test test_schedule.py --pep8 schedule -v --cov schedule --cov-report term-missing
-    python setup.py check
+    py.test test_schedule.py --flake8 schedule -v --cov schedule --cov-report term-missing
+    python setup.py check --strict --metadata --restructuredtext


### PR DESCRIPTION
- [x] bring in flake8 checks instead of pep8
- [x] unify local and CI build configs
- [x] build against Python 3.5 on CI
- [x] lock down dev requirements
- [x] validate setup.py config