### PR TITLE
Fix run_all with many cancel_job

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -71,7 +71,7 @@ class Scheduler(object):
         over time."""
         logger.info('Running *all* %i jobs with %is delay inbetween',
                     len(self.jobs), delay_seconds)
-        for job in self.jobs:
+        for job in self.jobs[:]:
             self._run_job(job)
             time.sleep(delay_seconds)
 

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -258,3 +258,15 @@ class SchedulerTests(unittest.TestCase):
 
         schedule.cancel_job(mj)
         assert len(schedule.jobs) == 0
+
+    def test_cancel_jobs(self):
+        def stop_job():
+            return schedule.CancelJob
+
+        every().second.do(stop_job)
+        every().second.do(stop_job)
+        every().second.do(stop_job)
+        assert len(schedule.jobs) == 3
+
+        schedule.run_all()
+        assert len(schedule.jobs) == 0


### PR DESCRIPTION
If you have many Jobs that are supposed to run only once (returns `CancelJob`)
The for loop in `run_all` is broken, since you can't remove items while iterating on the same array...
You have to iterate on a copy of the `self.jobs` array.
