### PR TITLE
Allow Scheduler to use custom Job class

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -47,7 +47,8 @@ class CancelJob(object):
 
 
 class Scheduler(object):
-    def __init__(self):
+    def __init__(self, job_cls=None):
+        self.job_cls = job_cls or Job
         self.jobs = []
 
     def run_pending(self):
@@ -88,7 +89,7 @@ class Scheduler(object):
 
     def every(self, interval=1):
         """Schedule a new periodic job."""
-        job = Job(interval)
+        job = self.job_cls(interval)
         self.jobs.append(job)
         return job
 

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -258,3 +258,21 @@ class SchedulerTests(unittest.TestCase):
 
         schedule.cancel_job(mj)
         assert len(schedule.jobs) == 0
+
+
+class SchedulerClassTests(unittest.TestCase):
+    def test_default_job_cls(self):
+        mock_job = make_mock_job()
+        s = schedule.Scheduler()
+        assert s.job_cls is schedule.Job
+        s.every().minute.do(mock_job)
+        assert isinstance(s.jobs[0], schedule.Job)
+
+    def test_custom_job_cls(self):
+        class CustomJob(schedule.Job):
+            pass
+        mock_job = make_mock_job()
+        s = schedule.Scheduler(job_cls=CustomJob)
+        assert s.job_cls is CustomJob
+        s.every().minute.do(mock_job)
+        assert isinstance(s.jobs[0], CustomJob)


### PR DESCRIPTION
Scheduler can be initialized with `job_cls` which it will use in
`every` to populate the `jobs` attribute.

The motivation for this change is to make it easier to decorate
`Job.run` with custom logic.

In our use case, for example, we use schedule to run a mix of
regular python functions and celery tasks. The existing behavior
is to log `job_func.__name__`. This is fine for normal functions,
but is always `delay` for celery tasks. To address this we simply
subclassed `Job` and added a bit of logging logic to `run`.

We also opted to initialize `Scheduler` ourselves instead of relying
on `schedule.default_schedule` which means that it wasn't enough to
patch `schedule.Job` by assignment; we had to subclass `Scheduler`
and override the `every` method to use our custom Job class.

I'm not tied to this implementation, I used the `None` pattern only
because `Job` is defined after `Scheduler` and I wanted to keep the
diff simple.

Other options (both require defining `Job` first):
1. keep `__init__` as is but expose job_cls as an attribute:
   
   ```
   class Scheduler(object):
       job_cls = Job
       def __init__(self):
           ...
   ```
   
   This has the advantage of keeping `__init__` simple while still
   allowing for more advanced configuration via subclassing or
   assignment.
2. default the `job_cls` kwarg in `__init__` to `Job` instead of `None`:
   
   ```
   class Scheduler(object):
       def __init__(self, job_cls=Job):
   ```
   
   In my opinion this is cleaner than the `None` pattern
   because it shows what the default is right in the signature and
   removes the `or` syntax in the `__init__` body.
