### PR TITLE
Zero out accumulated time drift, and assert cron-like behaviour

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ python:
     - "3.3"
 
 install:
-    - pip install pytest-cov --use-mirrors
-    - pip install pytest-pep8 --use-mirrors
-    - pip install coveralls --use-mirrors
+    - pip install pytest-cov
+    - pip install pytest-pep8
+    - pip install coveralls
 
 script: py.test test_schedule.py --pep8 schedule -v --cov schedule --cov-report term-missing
 


### PR DESCRIPTION
The time diff between when `run()` is called, and when `self.last_run`
is assigned accumulates as time drift. If left unchecked, `run()` is
triggered later and later from the ideal trigger point at the 'top' of
the unit of trigger time.

For example, if

```
schedule.every().minute.do(job)
```

is called at precisely 10:45:12, and the job takes 1 second to run,
before this commit the job execution start times would appear roughly
like:

```
10:45:12
10:46:13
10:47:14
10:48:15
```

But, `schedule` is meant to replicate cron's behaviour. This means that
for the same 'every minute' job, the job execution start time should
look like:

```
10:46:00
10:47:00
10:48:00
```

Solve both these problems by zeroing out next_run's units that are
accumulating drift - these are units smaller than the unit of trigger
time. This both accounts for time drift and asserts the cron-like
behaviour of triggering at the 'top' of the corresponding time.
