### PR TITLE
add: python 3.5 to setup classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Natural Language :: English',
     ],
 )


### PR DESCRIPTION
Python 3.5 is already mentioned in **.travis.yml**, **docs/index.rst** and
**tox.ini** but seems to be missing in **HISTORY.rst**. [Fix for #109]