### PR TITLE
Run every minute at fixed rate, no drift.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ venv
 
 .cache
 docs/_build
+
+# IntelliJ IDEA folder
+.idea

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,3 +15,4 @@ Thanks to all the wonderful folks who have contributed to schedule over the year
 - schnepp <https://github.com/schnepp> <https://bitbucket.org/saschaschnepp>
 - grampajoe <https://github.com/grampajoe>
 - gilbsgilbs <https://github.com/gilbsgilbs>
+- dgrant <https://github.com/dgrant>

--- a/FAQ.rst
+++ b/FAQ.rst
@@ -217,3 +217,43 @@ How can I pass arguments to the job function?
 
     schedule.every(2).seconds.do(greet, name='Alice')
     schedule.every(4).seconds.do(greet, name='Bob')    
+
+How can I make a job run every day at a particular time?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+... code-block:: python
+
+    def job():
+        print 'Do your job here...'
+
+    schedule.every().day.at("02:30").do(job)
+    # OR
+    schedule.every().day.at("02:30:00").do(job)
+
+will run job() every day at 02:30. In other words, once per day, at 02:30
+
+How can I make a job run every hour at a particular time?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+... code-block:: python
+
+    def job():
+        print 'Do your job here...'
+
+    schedule.every().day.at(":30").do(job)
+    # OR
+    schedule.every().day.at(":30:00").do(job)
+
+will run job() at 00:30, 01:30, 02:30, etc... in other words, every hour at the half hour mark.
+
+How can I make a job run every minute at a particular time?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+... code-block:: python
+
+    def job():
+        print 'Do your job here...'
+
+    schedule.every().day.at("::00").do(job)
+
+will run job() at 00:00:00, 00:01:00, 00:02:00, etc... in other words, every hour and second of the day, at the 0 second mark.

--- a/FAQ.rst
+++ b/FAQ.rst
@@ -256,4 +256,4 @@ How can I make a job run every minute at a particular time?
 
     schedule.every().day.at("::00").do(job)
 
-will run job() at 00:00:00, 00:01:00, 00:02:00, etc... in other words, every hour and second of the day, at the 0 second mark.
+will run job() at 00:00:00, 00:01:00, 00:02:00, etc... in other words, every hour and minute of the day, at the 0 second mark.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 History
 -------
 
+0.next (TBD)
+++++++++++++++++++++
+
+- .at() now supports units of minutes, this adds support for running every minute, using '::00' syntax, similar to running every hour syntax ':00'
+- .at() now supports times with seconds in string
+- More assertions/validation of time string passed in to .at() function
+
 0.5.0 (2017-11-16)
 ++++++++++++++++++
 
@@ -21,9 +28,8 @@ History
 
 - Publish to PyPI as a universal (py2/py3) wheel
 
-
 0.4.0 (2016-11-28)
-++++++++++++++++++
+++++++++++++++++++++
 
 - Add proper HTML (Sphinx) docs available at https://schedule.readthedocs.io/
 - CI builds now run against Python 2.7 and 3.5 (3.3 and 3.4 should work fine but are untested)

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,8 @@ Usage
     schedule.every().hour.do(job)
     schedule.every().day.at("10:30").do(job)
     schedule.every(5).to(10).minutes.do(job)
+    schedule.every().hour.at(":45").do(job)
+    schedule.every().minute.at("::00").do(job)
     schedule.every().monday.do(job)
     schedule.every().wednesday.at("13:15").do(job)
 


### PR DESCRIPTION
Trying to extend .at() to apply to this case:

`every().minute.at('::30').do(mock_job)`