### PR TITLE
Update FAQ.rst

### DIFF
--- a/FAQ.rst
+++ b/FAQ.rst
@@ -59,6 +59,7 @@ If you want tighter control on the number of threads use a shared jobqueue and o
         while 1:
             job_func = jobqueue.get()
             job_func()
+            jobqueue.task_done()
 
     jobqueue = Queue.Queue()
 


### PR DESCRIPTION
Added a call to jobqueue.task_done(). This removes the respective job from the queue after it was obtained by .get(). As the associated action is jobqueue.put the queue will fill up with every scheduled run if finished jobs are not removed. #134