### PR TITLE
Update url for clockwork and heroku

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -33,7 +33,7 @@ Usage:
     >>>     time.sleep(1)
 
 [1] https://adam.herokuapp.com/past/2010/4/13/rethinking_cron/
-[2] https://github.com/adamwiggins/clockwork
+[2] https://github.com/Rykian/clockwork
 [3] https://adam.herokuapp.com/past/2010/6/30/replace_cron_with_clockwork/
 """
 import collections

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -32,9 +32,9 @@ Usage:
     >>>     schedule.run_pending()
     >>>     time.sleep(1)
 
-[1] http://adam.heroku.com/past/2010/4/13/rethinking_cron/
-[2] https://github.com/tomykaira/clockwork
-[3] http://adam.heroku.com/past/2010/6/30/replace_cron_with_clockwork/
+[1] https://adam.herokuapp.com/past/2010/4/13/rethinking_cron/
+[2] https://github.com/adamwiggins/clockwork
+[3] https://adam.herokuapp.com/past/2010/6/30/replace_cron_with_clockwork/
 """
 import collections
 import datetime


### PR DESCRIPTION
- heroku.com -> herokuapp.com
- fix dead (wrong?) clockwork github url. As [stated](https://github.com/adamwiggins/clockwork/commit/19822a95b9a4bc679f80a0965e841ee646a7c412) by Adam, old forked repo is no longer maintained, use new active one instead
- https for everyone

EDIT1: update active forked repo