### PR TITLE
Add support for scheduling up to one-second precision

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -329,19 +329,21 @@ class Job(object):
         Calling this is only valid for jobs scheduled to run
         every N day(s).
 
-        :param time_str: A string in `XX:YY` format.
+        :param time_str: A string in `HH:MM(:SS)` format.
         :return: The invoked job instance
         """
         assert self.unit in ('days', 'hours') or self.start_day
-        hour, minute = time_str.split(':')
+        hour, minute, *rest = time_str.split(':')
         minute = int(minute)
+        second = int(rest[0]) if len(rest) == 1 else 0
+        assert 0 <= second <= 59
         if self.unit == 'days' or self.start_day:
             hour = int(hour)
             assert 0 <= hour <= 23
         elif self.unit == 'hours':
             hour = 0
         assert 0 <= minute <= 59
-        self.at_time = datetime.time(hour, minute)
+        self.at_time = datetime.time(hour, minute, second)
         return self
 
     def do(self, job_func, *args, **kwargs):

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -68,6 +68,8 @@ class SchedulerTests(unittest.TestCase):
         mock_job = make_mock_job()
         assert every().day.at('10:30').do(mock_job).next_run.hour == 10
         assert every().day.at('10:30').do(mock_job).next_run.minute == 30
+        assert every().day.at('10:30').do(mock_job).next_run.second == 0
+        assert every().day.at('10:30:45').do(mock_job).next_run.second == 45
 
     def test_at_time_hour(self):
         with mock_datetime(2010, 1, 6, 12, 20):


### PR DESCRIPTION
I'm kind of obsessive about time, so in my home automation project I needed scheduling with a single second precision.

It's an exceedingly simple change, and I added the unit tests as well. Here's to hoping I might help someone else too!