### PR TITLE
Add optional tz argument to 'at' method

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -54,8 +54,9 @@ class CancelJob(object):
 
 class Scheduler(object):
     """
-    Objects instantiated by the `Scheduler` are factories to create
-    jobs, keep record of scheduled jobs and handle their execution.
+    Objects instantiated by the :class:`Scheduler <Scheduler>` are
+    factories to create jobs, keep record of scheduled jobs and
+    handle their execution.
     """
     def __init__(self):
         self.jobs = []
@@ -119,10 +120,9 @@ class Scheduler(object):
         Schedule a new periodic job.
 
         :param interval: A quantity of a certain time unit
-        :return: An empty job
+        :return: An unconfigured :class:`Job <Job>`
         """
-        job = Job(interval)
-        self.jobs.append(job)
+        job = Job(interval, self)
         return job
 
     def _run_job(self, job):
@@ -155,6 +155,11 @@ class Job(object):
     """
     A periodic job as used by :class:`Scheduler`.
 
+    :param interval: A quantity of a certain time unit
+    :param scheduler: The :class:`Scheduler <Scheduler>` instance that
+                      this job will register itself with once it has
+                      been fully configured in :meth:`Job.do()`.
+
     Every job runs at a given fixed time interval that is defined by:
 
     * a :meth:`time unit <Job.second>`
@@ -163,7 +168,7 @@ class Job(object):
     A job is usually created and returned by :meth:`Scheduler.every`
     method, which also defines its `interval`.
     """
-    def __init__(self, interval):
+    def __init__(self, interval, scheduler=None):
         self.interval = interval  # pause interval * unit between runs
         self.job_func = None  # the job job_func to run
         self.unit = None  # time units, e.g. 'minutes', 'hours', ...
@@ -173,6 +178,7 @@ class Job(object):
         self.period = None  # timedelta between runs, only valid for
         self.start_day = None  # Specific day of the week to start on
         self.tags = set()  # unique set of tags for the job
+        self.scheduler = scheduler  # scheduler to register with
 
     def __lt__(self, other):
         """
@@ -317,7 +323,7 @@ class Job(object):
         self.tags.update(tags)
         return self
 
-    def at(self, time_str, tz=None):
+    def at(self, time_str):
         """
         Schedule the job every day at a specific time.
 
@@ -336,7 +342,7 @@ class Job(object):
         elif self.unit == 'hours':
             hour = 0
         assert 0 <= minute <= 59
-        self.at_time = datetime.time(hour, minute, tzinfo=tz)
+        self.at_time = datetime.time(hour, minute)
         return self
 
     def do(self, job_func, *args, **kwargs):
@@ -359,6 +365,7 @@ class Job(object):
             # call will fail.
             pass
         self._schedule_next_run()
+        self.scheduler.jobs.append(self)
         return self
 
     @property

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -54,9 +54,8 @@ class CancelJob(object):
 
 class Scheduler(object):
     """
-    Objects instantiated by the :class:`Scheduler <Scheduler>` are
-    factories to create jobs, keep record of scheduled jobs and
-    handle their execution.
+    Objects instantiated by the `Scheduler` are factories to create
+    jobs, keep record of scheduled jobs and handle their execution.
     """
     def __init__(self):
         self.jobs = []
@@ -120,9 +119,10 @@ class Scheduler(object):
         Schedule a new periodic job.
 
         :param interval: A quantity of a certain time unit
-        :return: An unconfigured :class:`Job <Job>`
+        :return: An empty job
         """
-        job = Job(interval, self)
+        job = Job(interval)
+        self.jobs.append(job)
         return job
 
     def _run_job(self, job):
@@ -148,17 +148,12 @@ class Scheduler(object):
                  :meth:`next_run <Scheduler.next_run>`.
         """
         now = datetime.datetime.now(tz=self.at_time.tzinfo)
-        return (self.next_run - now).total_seconds()
+        return (self.next_run - datetime.datetime.now(tz=self.at_time.tzinfo)).total_seconds()
 
 
 class Job(object):
     """
     A periodic job as used by :class:`Scheduler`.
-
-    :param interval: A quantity of a certain time unit
-    :param scheduler: The :class:`Scheduler <Scheduler>` instance that
-                      this job will register itself with once it has
-                      been fully configured in :meth:`Job.do()`.
 
     Every job runs at a given fixed time interval that is defined by:
 
@@ -168,7 +163,7 @@ class Job(object):
     A job is usually created and returned by :meth:`Scheduler.every`
     method, which also defines its `interval`.
     """
-    def __init__(self, interval, scheduler=None):
+    def __init__(self, interval):
         self.interval = interval  # pause interval * unit between runs
         self.job_func = None  # the job job_func to run
         self.unit = None  # time units, e.g. 'minutes', 'hours', ...
@@ -178,7 +173,6 @@ class Job(object):
         self.period = None  # timedelta between runs, only valid for
         self.start_day = None  # Specific day of the week to start on
         self.tags = set()  # unique set of tags for the job
-        self.scheduler = scheduler  # scheduler to register with
 
     def __lt__(self, other):
         """
@@ -323,7 +317,7 @@ class Job(object):
         self.tags.update(tags)
         return self
 
-    def at(self, time_str):
+    def at(self, time_str, tz=None):
         """
         Schedule the job every day at a specific time.
 
@@ -342,7 +336,7 @@ class Job(object):
         elif self.unit == 'hours':
             hour = 0
         assert 0 <= minute <= 59
-        self.at_time = datetime.time(hour, minute)
+        self.at_time = datetime.time(hour, minute, tzinfo=tz)
         return self
 
     def do(self, job_func, *args, **kwargs):
@@ -365,7 +359,6 @@ class Job(object):
             # call will fail.
             pass
         self._schedule_next_run()
-        self.scheduler.jobs.append(self)
         return self
 
     @property


### PR DESCRIPTION
Users can now pass in a timezone class as a parameter when scheduling tasks