### PR TITLE
Fix coverage tracking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ python:
 install: pip install tox-travis coveralls
 script:
     - tox
-    - if [ $TRAVIS_TEST_RESULT -eq 0 ]; coveralls; fi
+    - if [ $TRAVIS_TEST_RESULT -eq 0 ]; then coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ python:
     - "2.7.11"
     - "3.5"
     - "3.6"
-install: pip install tox-travis
+install: pip install tox-travis coveralls
 script: tox
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ python:
     - "3.5"
     - "3.6"
 install: pip install tox-travis coveralls
-script: tox
-after_success: coveralls
+script:
+    - tox
+    - if [ $TRAVIS_TEST_RESULT -eq 0 ]; coveralls; fi

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -326,9 +326,6 @@ class Job(object):
         :param tags: A unique list of ``Hashable`` tags.
         :return: The invoked job instance
         """
-        if any([not isinstance(tag, collections.Hashable) for tag in tags]):
-            raise TypeError('Every tag should be hashable')
-
         if not all(isinstance(tag, collections.Hashable) for tag in tags):
             raise TypeError('Tags must be hashable')
         self.tags.update(tags)


### PR DESCRIPTION
Turns out `after_success` doesn't fail the build on Travis CI so we were running without updating coveralls.io for a while now: https://github.com/travis-ci/travis-ci/issues/758

We'll want to run the coveralls command as part of the regular build phase so that it breaks the build if we stop sending coverage data:

```sh
if [ $TRAVIS_TEST_RESULT -eq 0 ]; then coveralls; fi
```