### PR TITLE
 Support for parsing of string interval definitions 

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,3 +15,4 @@ Thanks to all the wonderful folks who have contributed to schedule over the year
 - schnepp <https://github.com/schnepp> <https://bitbucket.org/saschaschnepp>
 - grampajoe <https://github.com/grampajoe>
 - gilbsgilbs <https://github.com/gilbsgilbs>
+- ljanyst <https://github.com/ljanyst>

--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,8 @@ Usage
     schedule.every(5).to(10).minutes.do(job)
     schedule.every().monday.do(job)
     schedule.every().wednesday.at("13:15").do(job)
+    schedule.when('every wednesday at 13:15').do(job)
+    schedule.when('every 15 seconds').do(job)
 
     while True:
         schedule.run_pending()

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -16,6 +16,7 @@ Main Interface
 .. autodata:: jobs
 
 .. autofunction:: every
+.. autofunction:: when
 .. autofunction:: run_pending
 .. autofunction:: run_all
 .. autofunction:: clear

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,6 +47,8 @@ Usage
     schedule.every().day.at("10:30").do(job)
     schedule.every().monday.do(job)
     schedule.every().wednesday.at("13:15").do(job)
+    schedule.when('every wednesday at 13:15').do(job)
+    schedule.when('every 15 seconds').do(job)
 
     while True:
         schedule.run_pending()

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -9,7 +9,7 @@ import unittest
 # pylint: disable-msg=R0201,C0111,E0102,R0904,R0901
 
 import schedule
-from schedule import every
+from schedule import every, when
 
 
 def make_mock_job(name=None):
@@ -120,6 +120,27 @@ class SchedulerTests(unittest.TestCase):
             assert every().friday.do(mock_job).next_run.day == 8
             assert every().saturday.do(mock_job).next_run.day == 9
             assert every().sunday.do(mock_job).next_run.day == 10
+
+    def test_when(self):
+        mock_job = make_mock_job()
+
+        invalid_definitions = ['', 'foo bar', 'every 2', 'every 2 foobar',
+                               'every 2 to foo days', 'every monday at foo',
+                               'every monday at foo:bar']
+        valid_definitions = ['every 2 days', 'every 3 to 5 days',
+                             'every monday at 17:51']
+
+        for definition in invalid_definitions:
+            try:
+                when(definition).do(mock_job)
+                assert False, "Invalid definition should not be parsed"
+            except Exception:
+                pass
+
+        for definition in valid_definitions:
+            when(definition).do(mock_job)
+
+        when('every 2 days').when('every 2 days').do(mock_job)
 
     def test_run_all(self):
         mock_job = make_mock_job()


### PR DESCRIPTION
As a user, I want to be able to specify an interval definition as a string. This pull request implements this functionality. It parses the input string and calls the appropriate properties and functions. It slightly abuses `assert`s but you did not define any custom exceptions and I wanted to follow your style. 

This is how it works:
```python
schedule.when('every wednesday at 13:15').do(job)
schedule.when('every 15 seconds').do(job)
```