### PR TITLE
Fix incorrect code sample under "What if my task throws an exception?" in FAQs

### DIFF
--- a/FAQ.rst
+++ b/FAQ.rst
@@ -100,17 +100,19 @@ in a decorator like this:
 
     import functools
 
-    def catch_exceptions(job_func, cancel_on_failure=False):
-        @functools.wraps(job_func)
-        def wrapper(*args, **kwargs):
-            try:
-                return job_func(*args, **kwargs)
-            except:
-                import traceback
-                print(traceback.format_exc())
-                if cancel_on_failure:
-                    return schedule.CancelJob
-        return wrapper
+    def catch_exceptions(cancel_on_failure=False):
+        def catch_exceptions_decorator(job_func):
+            @functools.wraps(job_func)
+            def wrapper(*args, **kwargs):
+                try:
+                    return job_func(*args, **kwargs)
+                except:
+                    import traceback
+                    print(traceback.format_exc())
+                    if cancel_on_failure:
+                        return schedule.CancelJob
+            return wrapper
+        return catch_exceptions_decorator
 
     @catch_exceptions(cancel_on_failure=True)
     def bad_task():


### PR DESCRIPTION
The documentation FAQs provide a code sample under the section "What if my task throws an exception?", which when executed, throws

`TypeError: catch_exceptions() missing 1 required positional argument: 'job_func'`

This was discussed in **[this](https://github.com/dbader/schedule/issues/107)** thread and @Zerrossetto provided a correct implementation, but it hasn't been updated in the docs. This PR updates the docs with the correct implementation.