### PR TITLE
Add businessday option for Monday-Friday

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,7 @@ Usage
     schedule.every(5).to(10).minutes.do(job)
     schedule.every().monday.do(job)
     schedule.every().wednesday.at("13:15").do(job)
+    schedule.every().businessday.do(job)
 
     while True:
         schedule.run_pending()

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -179,6 +179,7 @@ class Job(object):
         self.next_run = None  # datetime of the next run
         self.period = None  # timedelta between runs, only valid for
         self.start_day = None  # Specific day of the week to start on
+        self.skip = []  # specific days of the week to skip (Monday is 0, Sunday is 6)
         self.tags = set()  # unique set of tags for the job
         self.scheduler = scheduler  # scheduler to register with
 
@@ -317,6 +318,12 @@ class Job(object):
         self.start_day = 'sunday'
         return self.weeks
 
+    @property
+    def businessday(self):
+        assert self.interval == 1, 'Use days instead of day'
+        self.skip = [5, 6] # skip saturdays and sundays
+        return self.days
+
     def tag(self, *tags):
         """
         Tags the job with one or more unique indentifiers.
@@ -396,7 +403,8 @@ class Job(object):
         """
         :return: ``True`` if the job should be run now.
         """
-        return datetime.datetime.now() >= self.next_run
+        return (datetime.datetime.now() >= self.next_run and
+            datetime.datetime.now().weekday() not in self.skip)
 
     def run(self):
         """

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -179,7 +179,7 @@ class Job(object):
         self.next_run = None  # datetime of the next run
         self.period = None  # timedelta between runs, only valid for
         self.start_day = None  # Specific day of the week to start on
-        self.skip = []  # specific days of the week to skip (Monday is 0, Sunday is 6)
+        self.skip = []   # specific days of the week to skip (Mon = 0, Sun = 6)
         self.tags = set()  # unique set of tags for the job
         self.scheduler = scheduler  # scheduler to register with
 
@@ -321,7 +321,7 @@ class Job(object):
     @property
     def businessday(self):
         assert self.interval == 1, 'Use days instead of day'
-        self.skip = [5, 6] # skip saturdays and sundays
+        self.skip = [5, 6]  # skip saturdays and sundays
         return self.days
 
     def tag(self, *tags):
@@ -404,7 +404,7 @@ class Job(object):
         :return: ``True`` if the job should be run now.
         """
         return (datetime.datetime.now() >= self.next_run and
-            datetime.datetime.now().weekday() not in self.skip)
+                datetime.datetime.now().weekday() not in self.skip)
 
     def run(self):
         """

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -210,32 +210,32 @@ class SchedulerTests(unittest.TestCase):
 
     def test_run_every_businessday(self):
         mock_job = make_mock_job()
-        with mock_datetime(2010, 1, 7, 13, 16): # thursday
+        with mock_datetime(2010, 1, 7, 13, 16):  # thursday
             every().businessday.at('14:12').do(mock_job)
             schedule.run_pending()
             assert mock_job.call_count == 0
 
-        with mock_datetime(2010, 1, 7, 14, 16): # thursday
+        with mock_datetime(2010, 1, 7, 14, 16):  # thursday
             schedule.run_pending()
             assert mock_job.call_count == 1
 
-        with mock_datetime(2010, 1, 8, 14, 16): # friday
+        with mock_datetime(2010, 1, 8, 14, 16):  # friday
             schedule.run_pending()
             assert mock_job.call_count == 2
 
-        with mock_datetime(2010, 1, 9, 14, 16): # saturday
+        with mock_datetime(2010, 1, 9, 14, 16):  # saturday
             schedule.run_pending()
             assert mock_job.call_count == 2
 
-        with mock_datetime(2010, 1, 10, 14, 16): # sunday
+        with mock_datetime(2010, 1, 10, 14, 16):  # sunday
             schedule.run_pending()
             assert mock_job.call_count == 2
 
-        with mock_datetime(2010, 1, 11, 14, 16): # monday
+        with mock_datetime(2010, 1, 11, 14, 16):  # monday
             schedule.run_pending()
             assert mock_job.call_count == 3
 
-        with mock_datetime(2010, 1, 12, 14, 16): # tuesday
+        with mock_datetime(2010, 1, 12, 14, 16):  # tuesday
             schedule.run_pending()
             assert mock_job.call_count == 4
 
@@ -360,4 +360,3 @@ class SchedulerTests(unittest.TestCase):
         scheduler.every()
         scheduler.every(10).seconds
         scheduler.run_pending()
-

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -110,6 +110,7 @@ class SchedulerTests(unittest.TestCase):
             assert every(5).minutes.do(mock_job).next_run.minute == 20
             assert every().hour.do(mock_job).next_run.hour == 13
             assert every().day.do(mock_job).next_run.day == 7
+            assert every().businessday.do(mock_job).next_run.day == 7
             assert every().day.at('09:00').do(mock_job).next_run.day == 7
             assert every().day.at('12:30').do(mock_job).next_run.day == 6
             assert every().week.do(mock_job).next_run.day == 13
@@ -206,6 +207,37 @@ class SchedulerTests(unittest.TestCase):
         with mock_datetime(2010, 1, 6, 14, 16):
             schedule.run_pending()
             assert mock_job.call_count == 1
+
+    def test_run_every_businessday(self):
+        mock_job = make_mock_job()
+        with mock_datetime(2010, 1, 7, 13, 16): # thursday
+            every().businessday.at('14:12').do(mock_job)
+            schedule.run_pending()
+            assert mock_job.call_count == 0
+
+        with mock_datetime(2010, 1, 7, 14, 16): # thursday
+            schedule.run_pending()
+            assert mock_job.call_count == 1
+
+        with mock_datetime(2010, 1, 8, 14, 16): # friday
+            schedule.run_pending()
+            assert mock_job.call_count == 2
+
+        with mock_datetime(2010, 1, 9, 14, 16): # saturday
+            schedule.run_pending()
+            assert mock_job.call_count == 2
+
+        with mock_datetime(2010, 1, 10, 14, 16): # sunday
+            schedule.run_pending()
+            assert mock_job.call_count == 2
+
+        with mock_datetime(2010, 1, 11, 14, 16): # monday
+            schedule.run_pending()
+            assert mock_job.call_count == 3
+
+        with mock_datetime(2010, 1, 12, 14, 16): # tuesday
+            schedule.run_pending()
+            assert mock_job.call_count == 4
 
     def test_run_every_weekday_at_specific_time_past_today(self):
         mock_job = make_mock_job()
@@ -328,3 +360,4 @@ class SchedulerTests(unittest.TestCase):
         scheduler.every()
         scheduler.every(10).seconds
         scheduler.run_pending()
+


### PR DESCRIPTION
This change introduces the `businessday` option - to run jobs Monday to Fridays, but skip the weekends.

Usage:
```
schedule.every().businessday.do(job)
```

I need this for a few projects and I'm sure I'm not the only one!