### PR TITLE
Run CI tests on Python 3.7 Redux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
     - "2.7.11"
     - "3.5"
     - "3.6"
+    - "3.7"
 install: pip install tox-travis coveralls
 script:
     - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, docs
+envlist = py27, py35, py36, docs
 
 [tox:travis]
 2.7.11 = py27, docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py27, py35, py36, docs
+envlist = py27, py35, py36, py37, docs
 
 [tox:travis]
 2.7.11 = py27, docs
 3.5 = py35, docs
 3.6 = py36, docs
+3.7 = py37, docs
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
TODO: Merge when TravisCI officially supports Python 3.7 (https://github.com/travis-ci/travis-ci/issues/9815)