### PR TITLE
Feature: Allow multiple times in `every().unit.at()`

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -537,33 +537,34 @@ class Job(object):
                 raise ScheduleValueError(('Invalid unit without'
                                           ' specifying start day'))
 
-            for at_time in self.at_times:
-                self.at_time = at_time
-                kwargs = {
-                    'second': self.at_time.second,
-                    'microsecond': 0
-                }
-                if self.unit == 'days' or self.start_day is not None:
-                    kwargs['hour'] = self.at_time.hour
-                if self.unit in ['days', 'hours'] or self.start_day is not None:
-                    kwargs['minute'] = self.at_time.minute
-                self.next_run = self.next_run.replace(**kwargs)
-                # If we are running for the first time, make sure we run
-                # at the specified time *today* (or *this hour*) as well
-                if not self.last_run:
-                    now = datetime.datetime.now()
-                    if (self.unit == 'days' and self.at_time > now.time() and
-                            self.interval == 1):
-                        self.next_run = self.next_run - datetime.timedelta(days=1)
-                    elif self.unit == 'hours' \
-                            and self.at_time.minute > now.minute \
-                            or (self.at_time.minute == now.minute
-                                and self.at_time.second > now.second):
-                        self.next_run = self.next_run - datetime.timedelta(hours=1)
-                    elif self.unit == 'minutes' \
-                            and self.at_time.second > now.second:
-                        self.next_run = self.next_run - \
-                                        datetime.timedelta(minutes=1)
+            self.at_time = self.at_times[self.counter]
+            kwargs = {
+                'second': self.at_time.second,
+                'microsecond': 0
+            }
+            if self.unit == 'days' or self.start_day is not None:
+                kwargs['hour'] = self.at_time.hour
+            if self.unit in ['days', 'hours'] or self.start_day is not None:
+                kwargs['minute'] = self.at_time.minute
+
+            self.next_run = self.next_run.replace(**kwargs)
+            # print(self.at_times)
+            # If we are running for the first time, make sure we run
+            # at the specified time *today* (or *this hour*) as well
+            if not self.last_run:
+                now = datetime.datetime.now()
+                if (self.unit == 'days' and self.at_time > now.time() and
+                        self.interval == 1):
+                    self.next_run = self.next_run - datetime.timedelta(days=1)
+                elif self.unit == 'hours' \
+                        and self.at_time.minute > now.minute \
+                        or (self.at_time.minute == now.minute
+                            and self.at_time.second > now.second):
+                    self.next_run = self.next_run - datetime.timedelta(hours=1)
+                elif self.unit == 'minutes' \
+                        and self.at_time.second > now.second:
+                    self.next_run = self.next_run - \
+                                    datetime.timedelta(minutes=1)
         if self.start_day is not None and self.at_times is not None:
             # Let's see if we will still make that time we specified today
             if (self.next_run - datetime.datetime.now()).days >= 7:

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -190,7 +190,7 @@ class Job(object):
         self.latest = None  # upper limit to the interval
         self.job_func = None  # the job job_func to run
         self.unit = None  # time units, e.g. 'minutes', 'hours', ...
-        self.at_time = None  # optional time at which this job runs
+        self.at_times = None  # optional time at which this job runs
         self.last_run = None  # datetime of the last run
         self.next_run = None  # datetime of the next run
         self.period = None  # timedelta between runs, only valid for
@@ -237,11 +237,11 @@ class Job(object):
                   for k, v in self.job_func.keywords.items()]
         call_repr = job_func_name + '(' + ', '.join(args + kwargs) + ')'
 
-        if self.at_time is not None:
+        if self.at_times is not None:
             return 'Every %s %s at %s do %s %s' % (
                    self.interval,
                    self.unit[:-1] if self.interval == 1 else self.unit,
-                   self.at_time, call_repr, timestats)
+                   self.at_times, call_repr, timestats)
         else:
             fmt = (
                 'Every %(interval)s ' +
@@ -392,7 +392,7 @@ class Job(object):
             raise ScheduleValueError(('Invalid unit (valid units are `days`, '
                                       '`hours`, and `minutes`)'))
 
-        self.at_time = []
+        self.at_times = []
         for time_str in time_strings:
             if not isinstance(time_str, str):
                 raise TypeError('at() should be passed a string')
@@ -433,7 +433,7 @@ class Job(object):
                 minute = 0
             minute = int(minute)
             second = int(second)
-            self.at_time.append(datetime.time(hour, minute, second))
+            self.at_times.append(datetime.time(hour, minute, second))
         return self
 
     def to(self, latest):
@@ -531,7 +531,7 @@ class Job(object):
             if days_ahead <= 0:  # Target day already happened this week
                 days_ahead += 7
             self.next_run += datetime.timedelta(days_ahead) - self.period
-        if self.at_time is not None:
+        if self.at_times is not None:
             if (self.unit not in ('days', 'hours', 'minutes')
                     and self.start_day is None):
                 raise ScheduleValueError(('Invalid unit without'
@@ -562,6 +562,7 @@ class Job(object):
                     self.next_run = self.next_run - \
                                     datetime.timedelta(minutes=1)
         if self.start_day is not None and self.at_time is not None:
+        if self.start_day is not None and self.at_times is not None:
             # Let's see if we will still make that time we specified today
             if (self.next_run - datetime.datetime.now()).days >= 7:
                 self.next_run -= self.period

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -440,6 +440,7 @@ class Job(object):
             minute = int(minute)
             second = int(second)
             self.at_times.append(datetime.time(hour, minute, second))
+        self.at_times = sorted(self.at_times)
         return self
 
     def to(self, latest):

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -389,20 +389,21 @@ class Job(object):
         """
         if (self.unit not in ('days', 'hours', 'minutes')
                 and not self.start_day):
-            raise ScheduleValueError('Invalid unit.')
+            raise ScheduleValueError(('Invalid unit (valid units are `days`, '
+                                      '`hours`, and `minutes`)'))
         if not isinstance(time_str, str):
-            raise TypeError('at() should be passed a string.')
+            raise TypeError('at() should be passed a string')
         if self.unit == 'days' or self.start_day:
             if not re.match(r'^([0-2]\d:)?[0-5]\d:[0-5]\d$', time_str):
-                raise ScheduleValueError('Invalid time format.')
+                raise ScheduleValueError('Invalid time format (valid format is (HH:)?MM:SS)')
         if self.unit == 'hours':
             if not re.match(r'^([0-5]\d)?:[0-5]\d$', time_str):
                 raise ScheduleValueError(('Invalid time format for'
-                                          ' an hourly job.'))
+                                          ' an hourly job (valid format is MM:SS)'))
         if self.unit == 'minutes':
             if not re.match(r'^:[0-5]\d$', time_str):
                 raise ScheduleValueError(('Invalid time format for'
-                                          ' a minutely job.'))
+                                          ' a minutely job (valid format is :SS)'))
         time_values = time_str.split(':')
         if len(time_values) == 3:
             hour, minute, second = time_values
@@ -416,7 +417,8 @@ class Job(object):
         if self.unit == 'days' or self.start_day:
             hour = int(hour)
             if not (0 <= hour <= 23):
-                raise ScheduleValueError('Invalid number of hours.')
+                raise ScheduleValueError(('Invalid number of hours ({} is not '
+                                          'between 0 and 23)').format(hour))
         elif self.unit == 'hours':
             hour = 0
         elif self.unit == 'minutes':
@@ -489,11 +491,13 @@ class Job(object):
         Compute the instant when this job should run next.
         """
         if self.unit not in ('seconds', 'minutes', 'hours', 'days', 'weeks'):
-            raise ScheduleValueError('Invalid unit.')
+            raise ScheduleValueError(('Invalid unit (valid units are `seconds`'
+                                      '`minutes`, `hours`, `days`, and'
+                                      '`weeks`)'))
 
         if self.latest is not None:
             if not (self.latest >= self.interval):
-                raise ScheduleError('`latest` is greater than `interval`.')
+                raise ScheduleError('`latest` is greater than `interval`')
             interval = random.randint(self.interval, self.latest)
         else:
             interval = self.interval
@@ -513,7 +517,8 @@ class Job(object):
                 'sunday'
             )
             if self.start_day not in weekdays:
-                raise ScheduleValueError('Invalid start day.')
+                raise ScheduleValueError(('Invalid start day (valid start '
+                                          'days are {})').format(weekdays))
             weekday = weekdays.index(self.start_day)
             days_ahead = weekday - self.next_run.weekday()
             if days_ahead <= 0:  # Target day already happened this week
@@ -523,7 +528,7 @@ class Job(object):
             if (self.unit not in ('days', 'hours', 'minutes')
                     and self.start_day is None):
                 raise ScheduleValueError(('Invalid unit without'
-                                          ' specifying start day.'))
+                                          ' specifying start day'))
             kwargs = {
                 'second': self.at_time.second,
                 'microsecond': 0

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -536,32 +536,34 @@ class Job(object):
                     and self.start_day is None):
                 raise ScheduleValueError(('Invalid unit without'
                                           ' specifying start day'))
-            kwargs = {
-                'second': self.at_time.second,
-                'microsecond': 0
-            }
-            if self.unit == 'days' or self.start_day is not None:
-                kwargs['hour'] = self.at_time.hour
-            if self.unit in ['days', 'hours'] or self.start_day is not None:
-                kwargs['minute'] = self.at_time.minute
-            self.next_run = self.next_run.replace(**kwargs)
-            # If we are running for the first time, make sure we run
-            # at the specified time *today* (or *this hour*) as well
-            if not self.last_run:
-                now = datetime.datetime.now()
-                if (self.unit == 'days' and self.at_time > now.time() and
-                        self.interval == 1):
-                    self.next_run = self.next_run - datetime.timedelta(days=1)
-                elif self.unit == 'hours' \
-                        and self.at_time.minute > now.minute \
-                        or (self.at_time.minute == now.minute
-                            and self.at_time.second > now.second):
-                    self.next_run = self.next_run - datetime.timedelta(hours=1)
-                elif self.unit == 'minutes' \
-                        and self.at_time.second > now.second:
-                    self.next_run = self.next_run - \
-                                    datetime.timedelta(minutes=1)
-        if self.start_day is not None and self.at_time is not None:
+
+            for at_time in self.at_times:
+                self.at_time = at_time
+                kwargs = {
+                    'second': self.at_time.second,
+                    'microsecond': 0
+                }
+                if self.unit == 'days' or self.start_day is not None:
+                    kwargs['hour'] = self.at_time.hour
+                if self.unit in ['days', 'hours'] or self.start_day is not None:
+                    kwargs['minute'] = self.at_time.minute
+                self.next_run = self.next_run.replace(**kwargs)
+                # If we are running for the first time, make sure we run
+                # at the specified time *today* (or *this hour*) as well
+                if not self.last_run:
+                    now = datetime.datetime.now()
+                    if (self.unit == 'days' and self.at_time > now.time() and
+                            self.interval == 1):
+                        self.next_run = self.next_run - datetime.timedelta(days=1)
+                    elif self.unit == 'hours' \
+                            and self.at_time.minute > now.minute \
+                            or (self.at_time.minute == now.minute
+                                and self.at_time.second > now.second):
+                        self.next_run = self.next_run - datetime.timedelta(hours=1)
+                    elif self.unit == 'minutes' \
+                            and self.at_time.second > now.second:
+                        self.next_run = self.next_run - \
+                                        datetime.timedelta(minutes=1)
         if self.start_day is not None and self.at_times is not None:
             # Let's see if we will still make that time we specified today
             if (self.next_run - datetime.datetime.now()).days >= 7:

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -394,9 +394,9 @@ class Job(object):
         if not isinstance(time_str, str):
             raise TypeError('at() should be passed a string')
         if self.unit == 'days' or self.start_day:
-            if not re.match(r'^([0-2]?\d:)?[0-5]\d:[0-5]\d$', time_str):
+            if not re.match(r'^[0-2]?\d:[0-5]\d(:[0-5]\d)?$', time_str):
                 raise ScheduleValueError(('Invalid time format '
-                                          '(valid format is (H?H:)?MM:SS)'))
+                                          '(valid format is H?H:MM(:SS)?)'))
         if self.unit == 'hours':
             if not re.match(r'^([0-5]\d)?:[0-5]\d$', time_str):
                 raise ScheduleValueError(('Invalid time format for '

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -519,7 +519,7 @@ class Job(object):
         else:
             interval = self.interval
 
-        if self.at_times is not None:
+        if self.at_times: # can be None or []
             this_time = self.at_times[self.at_times_counter]
 
         if self.at_times_counter == 0:

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -193,9 +193,9 @@ class Job(object):
         self.at_times = None  # optional time at which this job runs
         self.last_run = None  # datetime of the last run
         self.next_run = None  # datetime of the next run
-        self.at_times_counter = 0
+        self.at_times_counter = 0  # index of self.at_times
         self.period = None  # timedelta between runs, only valid for
-        self.start_day = None  # Specific day of the week to start on
+        self.start_day = None  # specific day of the week to start on
         self.tags = set()  # unique set of tags for the job
         self.scheduler = scheduler  # scheduler to register with
 
@@ -386,12 +386,13 @@ class Job(object):
         """
         Specify a particular time that the job should be run at.
 
-        :param time_str: A string in one of the following formats: `HH:MM:SS`,
-            `HH:MM`,`:MM`, `:SS`. The format must make sense given how often
-            the job is repeating; for example, a job that repeats every minute
-            should not be given a string in the form `HH:MM:SS`. The difference
-            between `:MM` and `:SS` is inferred from the selected time-unit
-            (e.g. `every().hour.at(':30')` vs. `every().minute.at(':30')`).
+        :param time_strings: Strings in one of the following formats:
+            `HH:MM:SS`, `HH:MM`,`:MM`, `:SS`. The format must make sense given
+            how often the job is repeating; for example, a job that repeats
+            every minute should not be given a string in the form `HH:MM:SS`.
+            The difference between `:MM` and `:SS` is inferred from the
+            selected time-unit (e.g. `every().hour.at(':30')` vs.
+            `every().minute.at(':30')`).
         :return: The invoked job instance
         """
         if (self.unit not in ('days', 'hours', 'minutes')

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -519,7 +519,7 @@ class Job(object):
         else:
             interval = self.interval
 
-        if self.at_times: # can be None or []
+        if self.at_times:  # can be None or []
             this_time = self.at_times[self.at_times_counter]
 
         if self.at_times_counter == 0:
@@ -562,7 +562,6 @@ class Job(object):
                 kwargs['minute'] = this_time.minute
 
             self.next_run = self.next_run.replace(**kwargs)
-            # print(self.at_times)
             # If we are running for the first time, make sure we run
             # at the specified time *today* (or *this hour*) as well
             if not self.last_run:

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -517,7 +517,7 @@ class Job(object):
             interval = self.interval
 
         if self.at_times is not None:
-            self.at_time = self.at_times[self.at_times_counter]
+            this_time = self.at_times[self.at_times_counter]
 
         if self.at_times_counter == 0:
             self.period = datetime.timedelta(**{self.unit: interval})
@@ -550,13 +550,13 @@ class Job(object):
                                           ' specifying start day'))
 
             kwargs = {
-                'second': self.at_time.second,
+                'second': this_time.second,
                 'microsecond': 0
             }
             if self.unit == 'days' or self.start_day is not None:
-                kwargs['hour'] = self.at_time.hour
+                kwargs['hour'] = this_time.hour
             if self.unit in ['days', 'hours'] or self.start_day is not None:
-                kwargs['minute'] = self.at_time.minute
+                kwargs['minute'] = this_time.minute
 
             self.next_run = self.next_run.replace(**kwargs)
             # print(self.at_times)
@@ -564,16 +564,16 @@ class Job(object):
             # at the specified time *today* (or *this hour*) as well
             if not self.last_run:
                 now = datetime.datetime.now()
-                if (self.unit == 'days' and self.at_time > now.time() and
+                if (self.unit == 'days' and this_time > now.time() and
                         self.interval == 1):
                     self.next_run = self.next_run - datetime.timedelta(days=1)
                 elif self.unit == 'hours' \
-                        and self.at_time.minute > now.minute \
-                        or (self.at_time.minute == now.minute
-                            and self.at_time.second > now.second):
+                        and this_time.minute > now.minute \
+                        or (this_time.minute == now.minute
+                            and this_time.second > now.second):
                     self.next_run = self.next_run - datetime.timedelta(hours=1)
                 elif self.unit == 'minutes' \
-                        and self.at_time.second > now.second:
+                        and this_time.second > now.second:
                     self.next_run = self.next_run - \
                                     datetime.timedelta(minutes=1)
         if self.start_day is not None and self.at_times is not None:

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -399,12 +399,14 @@ class Job(object):
                                           '(valid format is (H?H:)?MM:SS)'))
         if self.unit == 'hours':
             if not re.match(r'^([0-5]\d)?:[0-5]\d$', time_str):
-                raise ScheduleValueError(('Invalid time format for'
-                                          ' an hourly job (valid format is MM:SS)'))
+                raise ScheduleValueError(('Invalid time format for '
+                                          'an hourly job (valid format '
+                                          'is (MM)?:SS)'))
         if self.unit == 'minutes':
             if not re.match(r'^:[0-5]\d$', time_str):
-                raise ScheduleValueError(('Invalid time format for'
-                                          ' a minutely job (valid format is :SS)'))
+                raise ScheduleValueError(('Invalid time format for '
+                                          'a minutely job (valid '
+                                          'format is :SS)'))
         time_values = time_str.split(':')
         if len(time_values) == 3:
             hour, minute, second = time_values

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -377,9 +377,10 @@ class Job(object):
         return self
 
     def increment_at_times_counter(self):
-        self.at_times_counter += 1
-        if self.at_times_counter >= len(self.at_times):
-            self.at_times_counter = 0
+        if self.at_times is not None:
+            self.at_times_counter += 1
+            if self.at_times_counter >= len(self.at_times):
+                self.at_times_counter = 0
 
     def at(self, *time_strings):
         """

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -190,7 +190,7 @@ class Job(object):
         self.latest = None  # upper limit to the interval
         self.job_func = None  # the job job_func to run
         self.unit = None  # time units, e.g. 'minutes', 'hours', ...
-        self.at_times = None  # optional time at which this job runs
+        self.at_times = None  # optional time(s) at which this job runs
         self.last_run = None  # datetime of the last run
         self.next_run = None  # datetime of the next run
         self.at_times_counter = 0  # index of self.at_times

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -394,8 +394,9 @@ class Job(object):
         if not isinstance(time_str, str):
             raise TypeError('at() should be passed a string')
         if self.unit == 'days' or self.start_day:
-            if not re.match(r'^([0-2]\d:)?[0-5]\d:[0-5]\d$', time_str):
-                raise ScheduleValueError('Invalid time format (valid format is (HH:)?MM:SS)')
+            if not re.match(r'^([0-2]?\d:)?[0-5]\d:[0-5]\d$', time_str):
+                raise ScheduleValueError(('Invalid time format '
+                                          '(valid format is (H?H:)?MM:SS)'))
         if self.unit == 'hours':
             if not re.match(r'^([0-5]\d)?:[0-5]\d$', time_str):
                 raise ScheduleValueError(('Invalid time format for'

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -407,7 +407,8 @@ class Job(object):
             if self.unit == 'days' or self.start_day:
                 if not re.match(r'^[0-2]?\d:[0-5]\d(:[0-5]\d)?$', time_str):
                     raise ScheduleValueError(('Invalid time format '
-                                              '(valid format is H?H:MM(:SS)?)'))
+                                              '(valid format is H?H'
+                                              ':MM(:SS)?)'))
             if self.unit == 'hours':
                 if not re.match(r'^([0-5]\d)?:[0-5]\d$', time_str):
                     raise ScheduleValueError(('Invalid time format for '
@@ -431,8 +432,9 @@ class Job(object):
             if self.unit == 'days' or self.start_day:
                 hour = int(hour)
                 if not (0 <= hour <= 23):
-                    raise ScheduleValueError(('Invalid number of hours ({} is not '
-                                              'between 0 and 23)').format(hour))
+                    raise ScheduleValueError(('Invalid number of hours '
+                                              '({} is not between 0 and'
+                                              ' 23)').format(hour))
             elif self.unit == 'hours':
                 hour = 0
             elif self.unit == 'minutes':

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -375,7 +375,7 @@ class Job(object):
         self.tags.update(tags)
         return self
 
-    def at(self, time_str):
+    def at(self, *time_strings):
         """
         Specify a particular time that the job should be run at.
 
@@ -391,45 +391,49 @@ class Job(object):
                 and not self.start_day):
             raise ScheduleValueError(('Invalid unit (valid units are `days`, '
                                       '`hours`, and `minutes`)'))
-        if not isinstance(time_str, str):
-            raise TypeError('at() should be passed a string')
-        if self.unit == 'days' or self.start_day:
-            if not re.match(r'^[0-2]?\d:[0-5]\d(:[0-5]\d)?$', time_str):
-                raise ScheduleValueError(('Invalid time format '
-                                          '(valid format is H?H:MM(:SS)?)'))
-        if self.unit == 'hours':
-            if not re.match(r'^([0-5]\d)?:[0-5]\d$', time_str):
-                raise ScheduleValueError(('Invalid time format for '
-                                          'an hourly job (valid format '
-                                          'is (MM)?:SS)'))
-        if self.unit == 'minutes':
-            if not re.match(r'^:[0-5]\d$', time_str):
-                raise ScheduleValueError(('Invalid time format for '
-                                          'a minutely job (valid '
-                                          'format is :SS)'))
-        time_values = time_str.split(':')
-        if len(time_values) == 3:
-            hour, minute, second = time_values
-        elif len(time_values) == 2 and self.unit == 'minutes':
-            hour = 0
-            minute = 0
-            _, second = time_values
-        else:
-            hour, minute = time_values
-            second = 0
-        if self.unit == 'days' or self.start_day:
-            hour = int(hour)
-            if not (0 <= hour <= 23):
-                raise ScheduleValueError(('Invalid number of hours ({} is not '
-                                          'between 0 and 23)').format(hour))
-        elif self.unit == 'hours':
-            hour = 0
-        elif self.unit == 'minutes':
-            hour = 0
-            minute = 0
-        minute = int(minute)
-        second = int(second)
-        self.at_time = datetime.time(hour, minute, second)
+
+        self.at_time = []
+        for time_str in time_strings:
+            if not isinstance(time_str, str):
+                raise TypeError('at() should be passed a string')
+
+            if self.unit == 'days' or self.start_day:
+                if not re.match(r'^[0-2]?\d:[0-5]\d(:[0-5]\d)?$', time_str):
+                    raise ScheduleValueError(('Invalid time format '
+                                              '(valid format is H?H:MM(:SS)?)'))
+            if self.unit == 'hours':
+                if not re.match(r'^([0-5]\d)?:[0-5]\d$', time_str):
+                    raise ScheduleValueError(('Invalid time format for '
+                                              'an hourly job (valid format '
+                                              'is (MM)?:SS)'))
+            if self.unit == 'minutes':
+                if not re.match(r'^:[0-5]\d$', time_str):
+                    raise ScheduleValueError(('Invalid time format for '
+                                              'a minutely job (valid '
+                                              'format is :SS)'))
+            time_values = time_str.split(':')
+            if len(time_values) == 3:
+                hour, minute, second = time_values
+            elif len(time_values) == 2 and self.unit == 'minutes':
+                hour = 0
+                minute = 0
+                _, second = time_values
+            else:
+                hour, minute = time_values
+                second = 0
+            if self.unit == 'days' or self.start_day:
+                hour = int(hour)
+                if not (0 <= hour <= 23):
+                    raise ScheduleValueError(('Invalid number of hours ({} is not '
+                                              'between 0 and 23)').format(hour))
+            elif self.unit == 'hours':
+                hour = 0
+            elif self.unit == 'minutes':
+                hour = 0
+                minute = 0
+            minute = int(minute)
+            second = int(second)
+            self.at_time.append(datetime.time(hour, minute, second))
         return self
 
     def to(self, latest):

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -303,7 +303,7 @@ class SchedulerTests(unittest.TestCase):
         assert s2.startswith(('Every 1 day at [datetime.time(0, 0)] do '
                               'job_fun(\'foo\', bar=23) (last run: '
                               '[never], next run: '))
-                              
+
         # test repr with multiple `at()` times
         s3 = repr(every().day.at("00:00", "00:05").do(job_fun, 'foo', bar=23))
         assert s3.startswith(('Every 1 day at [datetime.time(0, 0), '

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -290,16 +290,17 @@ class SchedulerTests(unittest.TestCase):
         def job_fun():
             pass
         s = repr(every().minute.do(job_fun, 'foo', bar=23))
-        assert s.startswith("Every 1 minute do job_fun('foo', bar=23) "
-                            "(last run: [never], next run: ")
+        assert s.startswith('Every 1 minute do job_fun(\'foo\', bar=23) '
+                            '(last run: [never], next run: ')
         assert 'job_fun' in s
         assert 'foo' in s
         assert 'bar=23' in s
 
         # test repr when at_time is not None
         s2 = repr(every().day.at("00:00").do(job_fun, 'foo', bar=23))
-        assert s2.startswith(("Every 1 day at [datetime.time(0, 0)] do job_fun('foo', "
-                              "bar=23) (last run: [never], next run: "))
+        assert s2.startswith(('Every 1 day at [datetime.time(0, 0)] do '
+                              'job_fun(\'foo\', bar=23) (last run: '
+                              '[never], next run: '))
 
     def test_to_string_lambda_job_func(self):
         assert len(str(every().minute.do(lambda: 1))) > 1

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -158,12 +158,20 @@ class SchedulerTests(unittest.TestCase):
         assert every().day.at('10:30').do(mock_job).next_run.minute == 30
         assert every().day.at('10:30:50').do(mock_job).next_run.second == 50
 
+        assert every().day.at('8:30').do(mock_job).next_run.hour == 8
+        assert every().day.at('8:30:50').do(mock_job).next_run.hour == 8
+        assert every().day.at('08:30').do(mock_job).next_run.hour == 8
+        assert every().day.at('08:30:50').do(mock_job).next_run.hour == 8
+
         self.assertRaises(ScheduleValueError, every().day.at, '2:30:000001')
         self.assertRaises(ScheduleValueError, every().day.at, '::2')
         self.assertRaises(ScheduleValueError, every().day.at, '.2')
         self.assertRaises(ScheduleValueError, every().day.at, '2')
         self.assertRaises(ScheduleValueError, every().day.at, ':2')
         self.assertRaises(ScheduleValueError, every().day.at, ' 2:30:00')
+        self.assertRaises(ScheduleValueError, every().day.at, '25:30:00')
+        self.assertRaises(ScheduleValueError, every().day.at, '25:30')
+        self.assertRaises(ScheduleValueError, every().day.at, '25')
         self.assertRaises(ScheduleValueError, every().do, lambda: 0)
         self.assertRaises(TypeError, every().day.at, 2)
 

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -298,7 +298,7 @@ class SchedulerTests(unittest.TestCase):
 
         # test repr when at_time is not None
         s2 = repr(every().day.at("00:00").do(job_fun, 'foo', bar=23))
-        assert s2.startswith(("Every 1 day at 00:00:00 do job_fun('foo', "
+        assert s2.startswith(("Every 1 day at [datetime.time(0, 0)] do job_fun('foo', "
                               "bar=23) (last run: [never], next run: "))
 
     def test_to_string_lambda_job_func(self):

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -253,6 +253,8 @@ class SchedulerTests(unittest.TestCase):
             assert every().day.do(mock_job).next_run.day == 7
             assert every().day.at('09:00').do(mock_job).next_run.day == 7
             assert every().day.at('12:30').do(mock_job).next_run.day == 6
+            run_times = ('09:00', '12:30')
+            assert every().day.at(*run_times).do(mock_job).next_run.hour == 9
             assert every().week.do(mock_job).next_run.day == 13
             assert every().monday.do(mock_job).next_run.day == 11
             assert every().tuesday.do(mock_job).next_run.day == 12
@@ -299,6 +301,13 @@ class SchedulerTests(unittest.TestCase):
         # test repr when at_time is not None
         s2 = repr(every().day.at("00:00").do(job_fun, 'foo', bar=23))
         assert s2.startswith(('Every 1 day at [datetime.time(0, 0)] do '
+                              'job_fun(\'foo\', bar=23) (last run: '
+                              '[never], next run: '))
+                              
+        # test repr with multiple `at()` times
+        s3 = repr(every().day.at("00:00", "00:05").do(job_fun, 'foo', bar=23))
+        assert s3.startswith(('Every 1 day at [datetime.time(0, 0), '
+                              'datetime.time(0, 5)] do '
                               'job_fun(\'foo\', bar=23) (last run: '
                               '[never], next run: '))
 


### PR DESCRIPTION
This pull request changes the syntax from 
```
schedule.every().minute.at(":00").do(lambda: 0)
schedule.every().minute.at(":05").do(lambda: 0)
schedule.every().minute.at(":10").do(lambda: 0)
```
to
```
schedule.every().minute.at(":00", ":05", ":10").do(lambda: 0)
```
or
```
run_times = (":00", ":05", ":10")
schedule.every().minute.at(*run_times).do(lambda: 0)
```
Current usage should remain unchanged
Resolves https://github.com/dbader/schedule/issues/269