### PR TITLE
Fix hour.at('MM:SS') parsing bug

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -424,7 +424,8 @@ class Job(object):
             hour = 0
             minute = 0
             _, second = time_values
-        elif len(time_values) == 2 and self.unit == 'hours' and len(time_values[0]):
+        elif len(time_values) == 2 and self.unit == 'hours' and \
+                len(time_values[0]):
             hour = 0
             minute, second = time_values
         else:

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -424,6 +424,9 @@ class Job(object):
             hour = 0
             minute = 0
             _, second = time_values
+        elif len(time_values) == 2 and self.unit == 'hours' and len(time_values[0]):
+            hour = 0
+            minute, second = time_values
         else:
             hour, minute = time_values
             second = 0

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -238,6 +238,17 @@ class SchedulerTests(unittest.TestCase):
             self.assertRaises(ScheduleValueError, every().hour.at, "01:61")
             self.assertRaises(TypeError, every().hour.at, 2)
 
+            # test the 'MM:SS' format
+            assert every().hour.at('30:05').do(mock_job).next_run.hour == 12
+            assert every().hour.at('30:05').do(mock_job).next_run.minute == 30
+            assert every().hour.at('30:05').do(mock_job).next_run.second == 5
+            assert every().hour.at('10:25').do(mock_job).next_run.hour == 13
+            assert every().hour.at('10:25').do(mock_job).next_run.minute == 10
+            assert every().hour.at('10:25').do(mock_job).next_run.second == 25
+            assert every().hour.at('00:40').do(mock_job).next_run.hour == 13
+            assert every().hour.at('00:40').do(mock_job).next_run.minute == 0
+            assert every().hour.at('00:40').do(mock_job).next_run.second == 40
+
     def test_at_time_minute(self):
         with mock_datetime(2010, 1, 6, 12, 20, 30):
             mock_job = make_mock_job()


### PR DESCRIPTION
Hi, 

This fix/feature was created after viewing issue #286:
https://github.com/dbader/schedule/issues/286

It's the first time I'm trying to change something here, so please excuse me if I didn't understand to wanted behaviour, I will appreciate any feedback that will be given to me :)

My first intension was to change the code so hour.at() could only get 'MM:SS' format instead of the current ':MM' format, because I could understand why @tangb4c think that this is the expected format.
I also saw in the code that there is no support for 'MM:SS' format but it doesn't raise an exception when the user use hour.at('HH:MM') format.

I didn't change it like I wanted, because this will cause unwanted behaviour for people who currently running the code with ':MM' format, So i decided that i will keep the old behaviour as it is, and add the support for 'MM:SS'  format

If the new fix/feature is not wanted for any reason, I will strongly advise to raise an error when a user try to run hour.at(''MM:SS').

Thanks
Elad