### PR TITLE
Adding :meth: `was_idle_seconds` 

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -167,6 +167,13 @@ class Scheduler(object):
         """
         return (self.next_run - datetime.datetime.now()).total_seconds()
 
+    @property
+    def was_idle_seconds(self):
+        """
+        :return: Number of seconds since last
+            :meth: `last_run` <Scheduler.last_run>`.
+        """
+        return (datetime.datetime.now() - self.last_run).total_seconds()
 
 class Job(object):
     """
@@ -612,3 +619,9 @@ def idle_seconds():
     :data:`default scheduler instance <default_scheduler>`.
     """
     return default_scheduler.idle_seconds
+
+def was_idle_seconds()
+    """Calls :meth: `was_idle_seconds <Scheduler.was_idle_seconds>` on the
+    :data:`default scheduler instance of <default_scheduler>`.
+    """
+    return default_scheduler.was_idle_seconds


### PR DESCRIPTION
Implement meth :was_idle_seconds: to tell us how long it's been since a scheduler was run, taking advantage of https://github.com/dbader/schedule/blob/master/schedule/__init__.py#L194

It's beneficial to know when the last schedule was ran to identify whether a scheduler is taking too long and skips an interval, or a scheduler stopped. E.g. 

```

`schedule.every(3).minutes.do(do_something)`

`idle_seconds`: Would tell us time until do_something() would be run
`was_idle_seconds`: Would tell us the last time do_something was run

```
