### PR TITLE
Improve testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
-sudo: false
+dist: xenial
 language: python
 python:
-    - "2.7.11"
+    - "2.7"
     - "3.5"
     - "3.6"
+    - "3.7"
+    - "3.8-dev"
+    - "nightly"
 install: pip install tox-travis coveralls
 script:
     - tox
-    - if [ $TRAVIS_TEST_RESULT -eq 0 ]; then coveralls; fi
+after_success:
+    - coveralls
+matrix:
+  allow_failures:
+    - python: "3.8-dev"
+    - python: "nightly"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
-docutils==0.13.1
-mock==2.0.0
-Pygments==2.2.0
-pytest-cov==2.5.1
-pytest-flake8==0.9.1
-pytest==3.2.5
-Sphinx==1.6.2
+docutils
+mock
+Pygments
+pytest
+pytest-cov
+pytest-flake8
+Sphinx

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,6 @@ $ python setup.py sdist bdist_wheel --universal
 $ twine upload dist/*
 """
 import codecs
-import os
-import sys
 from setuptools import setup
 
 
@@ -54,4 +52,5 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Natural Language :: English',
     ],
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,13 @@
 [tox]
-envlist = py27, py36, docs
+envlist = py27, py3{5,6,7,8}, docs
+skip_missing_interpreters = true
 
 [tox:travis]
-2.7.11 = py27, docs
+2.7 = py27, docs
 3.5 = py35, docs
 3.6 = py36, docs
+3.7 = py37, docs
+3.8 = py38, docs
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
Hello @dbader,

I believe it would be nice to have tests run over all supported and future Python versions.

These changes:
 - Enable testing over `3.7`, `3.8-dev`, and `nightly` on CI
 - Unpin test requirements
 - Add `python_requires` into `setup.py`
 - Supersede #244

Best regards!