### PR TITLE
Issue #296:  DeprecationWarning 'collections'

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -370,7 +370,7 @@ class Job(object):
         :param tags: A unique list of ``Hashable`` tags.
         :return: The invoked job instance
         """
-        if not all(isinstance(tag, collections.Hashable) for tag in tags):
+        if not all(isinstance(tag, collections.abc.Hashable) for tag in tags):
             raise TypeError('Tags must be hashable')
         self.tags.update(tags)
         return self

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -37,7 +37,10 @@ Usage:
 [2] https://github.com/Rykian/clockwork
 [3] https://adam.herokuapp.com/past/2010/6/30/replace_cron_with_clockwork/
 """
-import collections
+try:
+    from collections.abc import Hashable
+except ImportError:
+    from collections import Hashable
 import datetime
 import functools
 import logging
@@ -370,7 +373,7 @@ class Job(object):
         :param tags: A unique list of ``Hashable`` tags.
         :return: The invoked job instance
         """
-        if not all(isinstance(tag, collections.abc.Hashable) for tag in tags):
+        if not all(isinstance(tag, Hashable) for tag in tags):
             raise TypeError('Tags must be hashable')
         self.tags.update(tags)
         return self


### PR DESCRIPTION
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working

Tested with Python 3.7.3