### PR TITLE
Monthly periodicity

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -540,6 +540,8 @@ class Job(object):
             interval = self.interval
 
         if self.unit == 'months':
+            if self.at_time==None or self.at_day==None:
+                raise ScheduleError('Monthly jobs shoud have "at()" defined')
             self.next_run = self.addmonth(datetime.datetime.now(),
                                           self.interval)
         else:

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -595,7 +595,7 @@ class Job(object):
                     temp_date = self.next_run.replace(
                                     month=self.next_run.month + 1, day=1)
                     self.next_run = temp_date + \
-                                    datetime.timedelta(days=-1)
+                        datetime.timedelta(days=-1)
             # If we are running for the first time, make sure we run
             # at the specified time *today* (or *this hour*) as well
             if not self.last_run:
@@ -621,8 +621,8 @@ class Job(object):
                             temp_date = self.next_run.replace(
                                                  month=now.month + 1, day=1)
                             self.next_run = temp_date + \
-                                            datetime.timedelta(days=-1)
-                    elif (now.day == self.at_day and \
+                                datetime.timedelta(days=-1)
+                    elif (now.day == self.at_day and
                           now.time() < self.at_time):
                         self.next_run = now.replace(**kwargs)
                     else:
@@ -636,7 +636,7 @@ class Job(object):
                                             month=self.next_run.month + 1,
                                             day=1)
                             self.next_run = temp_date + \
-                                            datetime.timedelta(days=-1)
+                                datetime.timedelta(days=-1)
 
         if self.start_day is not None and self.at_time is not None:
             # Let's see if we will still make that time we specified today

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -629,12 +629,11 @@ class Job(object):
                         self.next_run = self.addmonth(now, 1)
                         self.next_run = self.next_run.replace(**kwargs)
                         try:
-                            self.next_run = \
-                                         self.next_run.replace(day=self.at_day)
+                            self.next_run = self.next_run.replace(
+                                                day=self.at_day)
                         except ValueError:
                             temp_date = now.replace(
-                                            month=self.next_run.month + 1,
-                                            day=1)
+                                        month=self.next_run.month + 1, day=1)
                             self.next_run = temp_date + \
                                 datetime.timedelta(days=-1)
 

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -396,7 +396,8 @@ class Job(object):
         if not isinstance(time_str, str):
             raise TypeError('at() should be passed a string')
         if self.unit == 'days' or self.start_day:
-            if not re.match(r'^([0-2]\d:)?[0-5]\d:[0-5]\d$', time_str):
+            if not re.match(r'^(2[0-3]|[01][0-9]):([0-5][0-9])(:[0-5][0-9])?$',
+                            time_str):
                 raise ScheduleValueError('Invalid time format')
         if self.unit == 'hours':
             if not re.match(r'^([0-5]\d)?:[0-5]\d$', time_str):
@@ -418,8 +419,6 @@ class Job(object):
             second = 0
         if self.unit == 'days' or self.start_day:
             hour = int(hour)
-            if not (0 <= hour <= 23):
-                raise ScheduleValueError('Invalid number of hours')
         elif self.unit == 'hours':
             hour = 0
         elif self.unit == 'minutes':

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -516,11 +516,14 @@ class Job(object):
     def addmonth(self,date,interval):
         targetmonth=interval+date.month
         try:
-            date = date.replace(year=date.year+int(targetmonth/12),month=(targetmonth%12))
+            date = date.replace(year=date.year+int(targetmonth/12),
+                                month=(targetmonth%12))
         except:
-            # There is an exception if the day of the month we're in does not exist in the target month
+            # There is an exception if the day of the month we're in does not
+            # exist in the target month.
             # Go to the FIRST of the month AFTER, then go back one day.
-            date = date.replace(year=date.year+int((targetmonth+1)/12),month=((targetmonth+1)%12),day=1)
+            date = date.replace(year=date.year+int((targetmonth+1)/12),
+                                month=((targetmonth+1)%12),day=1)
             date += datetime.timedelta(days=-1)
         return date
 
@@ -541,7 +544,7 @@ class Job(object):
 
         if self.unit == 'months':
             if self.at_time==None or self.at_day==None:
-                raise ScheduleError('Monthly jobs shoud have "at()" defined')
+                raise ScheduleError('Monthly jobs expect "at()" to be defined')
             self.next_run = self.addmonth(datetime.datetime.now(),
                                           self.interval)
         else:

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -193,7 +193,7 @@ class Job(object):
         self.latest = None  # upper limit to the interval
         self.job_func = None  # the job job_func to run
         self.unit = None  # time units, e.g. 'minutes', 'hours', ...
-        self.at_day = None  # optional time at which this job runs
+        self.at_day = None  # optional day at which this job runs
         self.at_time = None  # optional time at which this job runs
         self.last_run = None  # datetime of the last run
         self.next_run = None  # datetime of the next run

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -404,8 +404,9 @@ class SchedulerTests(unittest.TestCase):
                               every(2).months.at, '5-23:00')
 
         # test invalid month/months
-        with mock_datetime(2010, 1, 6, 12, 20, 30):
-            self.assertRaises(IntervalError, every(2).month.at, '31-10:00')
+        job_instance = schedule.Job(interval=2)
+        with self.assertRaises(IntervalError):
+            job_instance.month
 
     def test_next_run_time(self):
         with mock_datetime(2010, 1, 6, 12, 15):

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -249,31 +249,31 @@ class SchedulerTests(unittest.TestCase):
         with mock_datetime(2010, 1, 6, 12, 20, 30):
             mock_job = make_mock_job()
             assert every().month.at('06-12:40:30').do(mock_job).\
-                   next_run.month == 1
+                next_run.month == 1
             assert every().month.at('06-12:40:30').do(mock_job).\
-                   next_run.day == 6
+                next_run.day == 6
             assert every().month.at('06-12:40:30').do(mock_job).\
-                   next_run.hour == 12
+                next_run.hour == 12
             assert every().month.at('06-12:40:30').do(mock_job).\
-                   next_run.minute == 40
+                next_run.minute == 40
             assert every().month.at('06-12:40:30').do(mock_job).\
-                   next_run.second == 30
+                next_run.second == 30
             assert every().month.at('06-10:40:30').do(mock_job).\
-                   next_run.month == 2
+                next_run.month == 2
             assert every().month.at('04-12:40:30').do(mock_job).\
-                   next_run.day == 4
+                next_run.day == 4
             assert every().month.at('04-12:40:30').do(mock_job).\
-                   next_run.month == 2
+                next_run.month == 2
             assert every().month.at('19-12:40:30').do(mock_job).\
-                   next_run.day == 19
+                next_run.day == 19
             assert every().month.at('19-12:40:30').do(mock_job).\
-                   next_run.month == 1
+                next_run.month == 1
         with mock_datetime(2010, 2, 6, 12, 20, 30):
             mock_job = make_mock_job()
             assert every().month.at('31-12:40:30').do(mock_job).\
-                   next_run.day == 28
+                next_run.day == 28
             assert every().month.at('31-12:40:30').do(mock_job).\
-                   next_run.month == 2
+                next_run.month == 2
 
         # Test that the monthly scheduler creates correct next_run dates
         with mock_datetime(2010, 1, 6, 12, 20, 30):
@@ -304,7 +304,6 @@ class SchedulerTests(unittest.TestCase):
             scheduler.run_pending()
             assert scheduler.jobs[0].next_run.month == 4
             assert scheduler.jobs[0].next_run.day == 30
-
 
         # test invalid time format
         with mock_datetime(2010, 1, 6, 12, 20, 30):

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -403,6 +403,10 @@ class SchedulerTests(unittest.TestCase):
             self.assertRaises(ScheduleValueError,
                               every(2).months.at, '5-23:00')
 
+        # test invalid month/months
+        with mock_datetime(2010, 1, 6, 12, 20, 30):
+            self.assertRaises(IntervalError, every(2).month.at, '31-10:00')
+
     def test_next_run_time(self):
         with mock_datetime(2010, 1, 6, 12, 15):
             mock_job = make_mock_job()

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -311,6 +311,10 @@ class SchedulerTests(unittest.TestCase):
             self.assertRaises(ScheduleValueError, every().month.at, '15-10:0')
             self.assertRaises(ScheduleValueError, every().month.at, '5-23:00')
 
+        # test monthly job asks for "at()"
+        with mock_datetime(2010, 1, 6, 12, 20, 30):
+            self.assertRaises(ScheduleError, every().month.do, mock_job)
+
     def test_at_daytime_months(self):
         # Test that the monthly scheduler creates correct next_run dates
         with mock_datetime(2010, 1, 6, 12, 20, 30):

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -244,6 +244,85 @@ class SchedulerTests(unittest.TestCase):
             self.assertRaises(ScheduleValueError, every().minute.at, ' :30')
             self.assertRaises(TypeError, every().minute.at, 2)
 
+    def test_at_daytime_month(self):
+        # Test that the monthly schedulers creates the starting date correctly
+        with mock_datetime(2010, 1, 6, 12, 20, 30):
+            mock_job = make_mock_job()
+            assert every().month.at('06-12:40:30').do(mock_job).next_run.month == 1
+            assert every().month.at('06-12:40:30').do(mock_job).next_run.day == 6
+            assert every().month.at('06-12:40:30').do(mock_job).next_run.hour == 12
+            assert every().month.at('06-12:40:30').do(mock_job).next_run.minute == 40
+            assert every().month.at('06-12:40:30').do(mock_job).next_run.second == 30
+            assert every().month.at('06-10:40:30').do(mock_job).next_run.month == 2
+            assert every().month.at('04-12:40:30').do(mock_job).next_run.day == 4
+            assert every().month.at('04-12:40:30').do(mock_job).next_run.month == 2
+            assert every().month.at('19-12:40:30').do(mock_job).next_run.day == 19
+            assert every().month.at('19-12:40:30').do(mock_job).next_run.month == 1
+
+        # Test that the monthly scheduler creates correct next_run dates
+        with mock_datetime(2010, 1, 6, 12, 20, 30):
+            mock_job = make_mock_job()
+            scheduler = schedule.Scheduler()
+            scheduler.every().month.at('04-12:40:30').do(mock_job)
+        with mock_datetime(2010, 2, 4, 12, 40, 30):
+            scheduler.run_pending()
+            assert scheduler.jobs[0].next_run.month == 3
+        with mock_datetime(2010, 3, 4, 12, 40, 30):
+            scheduler.run_pending()
+            assert scheduler.jobs[0].next_run.month == 4
+
+        # test invalid time format
+        with mock_datetime(2010, 1, 6, 12, 20, 30):
+            self.assertRaises(ScheduleValueError, every().month.at, '32-10:00:00')
+            self.assertRaises(ScheduleValueError, every().month.at, '05-24:00:00')
+            self.assertRaises(ScheduleValueError, every().month.at, '05-20:60:00')
+            self.assertRaises(ScheduleValueError, every().month.at, '05-20:00:65')
+            self.assertRaises(ScheduleValueError, every().month.at, '32-10:00')
+            self.assertRaises(ScheduleValueError, every().month.at, '05-24:00')
+            self.assertRaises(ScheduleValueError, every().month.at, '05-20:60')
+            self.assertRaises(ScheduleValueError, every().month.at, '15-1:00:00')
+            self.assertRaises(ScheduleValueError, every().month.at, '15-10:0:00')
+            self.assertRaises(ScheduleValueError, every().month.at, '15-10:00:0')
+            self.assertRaises(ScheduleValueError, every().month.at, '5-23:00:00')
+            self.assertRaises(ScheduleValueError, every().month.at, '15-1:00')
+            self.assertRaises(ScheduleValueError, every().month.at, '15-10:0')
+            self.assertRaises(ScheduleValueError, every().month.at, '5-23:00')
+
+    def test_at_daytime_months(self):
+        # Test that the monthly scheduler creates correct next_run dates
+        with mock_datetime(2010, 1, 6, 12, 20, 30):
+            mock_job = make_mock_job()
+            scheduler = schedule.Scheduler()
+            scheduler.every(5).months.at('04-12:40:30').do(mock_job)
+            assert scheduler.jobs[0].next_run.month == 2
+        with mock_datetime(2010, 2, 4, 12, 40, 30):
+            scheduler.run_pending()
+            assert scheduler.jobs[0].next_run.month == 7
+        with mock_datetime(2010, 7, 4, 12, 40, 30):
+            scheduler.run_pending()
+            assert scheduler.jobs[0].next_run.month == 12
+        with mock_datetime(2010, 12, 4, 12, 40, 30):
+            scheduler.run_pending()
+            assert scheduler.jobs[0].next_run.month == 5
+            assert scheduler.jobs[0].next_run.year == 2011
+
+        # test invalid time format
+        with mock_datetime(2010, 1, 6, 12, 20, 30):
+            self.assertRaises(ScheduleValueError, every(2).months.at, '32-10:00:00')
+            self.assertRaises(ScheduleValueError, every(2).months.at, '05-24:00:00')
+            self.assertRaises(ScheduleValueError, every(2).months.at, '05-20:60:00')
+            self.assertRaises(ScheduleValueError, every(2).months.at, '05-20:00:65')
+            self.assertRaises(ScheduleValueError, every(2).months.at, '32-10:00')
+            self.assertRaises(ScheduleValueError, every(2).months.at, '05-24:00')
+            self.assertRaises(ScheduleValueError, every(2).months.at, '05-20:60')
+            self.assertRaises(ScheduleValueError, every(2).months.at, '15-1:00:00')
+            self.assertRaises(ScheduleValueError, every(2).months.at, '15-10:0:00')
+            self.assertRaises(ScheduleValueError, every(2).months.at, '15-10:00:0')
+            self.assertRaises(ScheduleValueError, every(2).months.at, '5-23:00:00')
+            self.assertRaises(ScheduleValueError, every(2).months.at, '15-1:00')
+            self.assertRaises(ScheduleValueError, every(2).months.at, '15-10:0')
+            self.assertRaises(ScheduleValueError, every(2).months.at, '5-23:00')
+
     def test_next_run_time(self):
         with mock_datetime(2010, 1, 6, 12, 15):
             mock_job = make_mock_job()

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -268,6 +268,12 @@ class SchedulerTests(unittest.TestCase):
                 next_run.day == 19
             assert every().month.at('19-12:40:30').do(mock_job).\
                 next_run.month == 1
+        with mock_datetime(2010, 1, 31, 12, 20, 30):
+            mock_job = make_mock_job()
+            assert every().month.at('31-06:00:00').do(mock_job).\
+                next_run.month == 2
+            assert every().month.at('31-06:00:00').do(mock_job).\
+                next_run.day == 28
         with mock_datetime(2010, 2, 6, 12, 20, 30):
             mock_job = make_mock_job()
             assert every().month.at('31-12:40:30').do(mock_job).\

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -248,20 +248,32 @@ class SchedulerTests(unittest.TestCase):
         # Test that the monthly schedulers creates the starting date correctly
         with mock_datetime(2010, 1, 6, 12, 20, 30):
             mock_job = make_mock_job()
-            assert every().month.at('06-12:40:30').do(mock_job).next_run.month == 1
-            assert every().month.at('06-12:40:30').do(mock_job).next_run.day == 6
-            assert every().month.at('06-12:40:30').do(mock_job).next_run.hour == 12
-            assert every().month.at('06-12:40:30').do(mock_job).next_run.minute == 40
-            assert every().month.at('06-12:40:30').do(mock_job).next_run.second == 30
-            assert every().month.at('06-10:40:30').do(mock_job).next_run.month == 2
-            assert every().month.at('04-12:40:30').do(mock_job).next_run.day == 4
-            assert every().month.at('04-12:40:30').do(mock_job).next_run.month == 2
-            assert every().month.at('19-12:40:30').do(mock_job).next_run.day == 19
-            assert every().month.at('19-12:40:30').do(mock_job).next_run.month == 1
+            assert every().month.at('06-12:40:30').do(mock_job).\
+                   next_run.month == 1
+            assert every().month.at('06-12:40:30').do(mock_job).\
+                   next_run.day == 6
+            assert every().month.at('06-12:40:30').do(mock_job).\
+                   next_run.hour == 12
+            assert every().month.at('06-12:40:30').do(mock_job).\
+                   next_run.minute == 40
+            assert every().month.at('06-12:40:30').do(mock_job).\
+                   next_run.second == 30
+            assert every().month.at('06-10:40:30').do(mock_job).\
+                   next_run.month == 2
+            assert every().month.at('04-12:40:30').do(mock_job).\
+                   next_run.day == 4
+            assert every().month.at('04-12:40:30').do(mock_job).\
+                   next_run.month == 2
+            assert every().month.at('19-12:40:30').do(mock_job).\
+                   next_run.day == 19
+            assert every().month.at('19-12:40:30').do(mock_job).\
+                   next_run.month == 1
         with mock_datetime(2010, 2, 6, 12, 20, 30):
             mock_job = make_mock_job()
-            assert every().month.at('31-12:40:30').do(mock_job).next_run.day == 28
-            assert every().month.at('31-12:40:30').do(mock_job).next_run.month == 2
+            assert every().month.at('31-12:40:30').do(mock_job).\
+                   next_run.day == 28
+            assert every().month.at('31-12:40:30').do(mock_job).\
+                   next_run.month == 2
 
         # Test that the monthly scheduler creates correct next_run dates
         with mock_datetime(2010, 1, 6, 12, 20, 30):
@@ -296,20 +308,34 @@ class SchedulerTests(unittest.TestCase):
 
         # test invalid time format
         with mock_datetime(2010, 1, 6, 12, 20, 30):
-            self.assertRaises(ScheduleValueError, every().month.at, '32-10:00:00')
-            self.assertRaises(ScheduleValueError, every().month.at, '05-24:00:00')
-            self.assertRaises(ScheduleValueError, every().month.at, '05-20:60:00')
-            self.assertRaises(ScheduleValueError, every().month.at, '05-20:00:65')
-            self.assertRaises(ScheduleValueError, every().month.at, '32-10:00')
-            self.assertRaises(ScheduleValueError, every().month.at, '05-24:00')
-            self.assertRaises(ScheduleValueError, every().month.at, '05-20:60')
-            self.assertRaises(ScheduleValueError, every().month.at, '15-1:00:00')
-            self.assertRaises(ScheduleValueError, every().month.at, '15-10:0:00')
-            self.assertRaises(ScheduleValueError, every().month.at, '15-10:00:0')
-            self.assertRaises(ScheduleValueError, every().month.at, '5-23:00:00')
-            self.assertRaises(ScheduleValueError, every().month.at, '15-1:00')
-            self.assertRaises(ScheduleValueError, every().month.at, '15-10:0')
-            self.assertRaises(ScheduleValueError, every().month.at, '5-23:00')
+            self.assertRaises(ScheduleValueError,
+                              every().month.at, '32-10:00:00')
+            self.assertRaises(ScheduleValueError,
+                              every().month.at, '05-24:00:00')
+            self.assertRaises(ScheduleValueError,
+                              every().month.at, '05-20:60:00')
+            self.assertRaises(ScheduleValueError,
+                              every().month.at, '05-20:00:65')
+            self.assertRaises(ScheduleValueError,
+                              every().month.at, '32-10:00')
+            self.assertRaises(ScheduleValueError,
+                              every().month.at, '05-24:00')
+            self.assertRaises(ScheduleValueError,
+                              every().month.at, '05-20:60')
+            self.assertRaises(ScheduleValueError,
+                              every().month.at, '15-1:00:00')
+            self.assertRaises(ScheduleValueError,
+                              every().month.at, '15-10:0:00')
+            self.assertRaises(ScheduleValueError,
+                              every().month.at, '15-10:00:0')
+            self.assertRaises(ScheduleValueError,
+                              every().month.at, '5-23:00:00')
+            self.assertRaises(ScheduleValueError,
+                              every().month.at, '15-1:00')
+            self.assertRaises(ScheduleValueError,
+                              every().month.at, '15-10:0')
+            self.assertRaises(ScheduleValueError,
+                              every().month.at, '5-23:00')
 
         # test monthly job asks for "at()"
         with mock_datetime(2010, 1, 6, 12, 20, 30):
@@ -349,20 +375,34 @@ class SchedulerTests(unittest.TestCase):
 
         # test invalid time format
         with mock_datetime(2010, 1, 6, 12, 20, 30):
-            self.assertRaises(ScheduleValueError, every(2).months.at, '32-10:00:00')
-            self.assertRaises(ScheduleValueError, every(2).months.at, '05-24:00:00')
-            self.assertRaises(ScheduleValueError, every(2).months.at, '05-20:60:00')
-            self.assertRaises(ScheduleValueError, every(2).months.at, '05-20:00:65')
-            self.assertRaises(ScheduleValueError, every(2).months.at, '32-10:00')
-            self.assertRaises(ScheduleValueError, every(2).months.at, '05-24:00')
-            self.assertRaises(ScheduleValueError, every(2).months.at, '05-20:60')
-            self.assertRaises(ScheduleValueError, every(2).months.at, '15-1:00:00')
-            self.assertRaises(ScheduleValueError, every(2).months.at, '15-10:0:00')
-            self.assertRaises(ScheduleValueError, every(2).months.at, '15-10:00:0')
-            self.assertRaises(ScheduleValueError, every(2).months.at, '5-23:00:00')
-            self.assertRaises(ScheduleValueError, every(2).months.at, '15-1:00')
-            self.assertRaises(ScheduleValueError, every(2).months.at, '15-10:0')
-            self.assertRaises(ScheduleValueError, every(2).months.at, '5-23:00')
+            self.assertRaises(ScheduleValueError,
+                              every(2).months.at, '32-10:00:00')
+            self.assertRaises(ScheduleValueError,
+                              every(2).months.at, '05-24:00:00')
+            self.assertRaises(ScheduleValueError,
+                              every(2).months.at, '05-20:60:00')
+            self.assertRaises(ScheduleValueError,
+                              every(2).months.at, '05-20:00:65')
+            self.assertRaises(ScheduleValueError,
+                              every(2).months.at, '32-10:00')
+            self.assertRaises(ScheduleValueError,
+                              every(2).months.at, '05-24:00')
+            self.assertRaises(ScheduleValueError,
+                              every(2).months.at, '05-20:60')
+            self.assertRaises(ScheduleValueError,
+                              every(2).months.at, '15-1:00:00')
+            self.assertRaises(ScheduleValueError,
+                              every(2).months.at, '15-10:0:00')
+            self.assertRaises(ScheduleValueError,
+                              every(2).months.at, '15-10:00:0')
+            self.assertRaises(ScheduleValueError,
+                              every(2).months.at, '5-23:00:00')
+            self.assertRaises(ScheduleValueError,
+                              every(2).months.at, '15-1:00')
+            self.assertRaises(ScheduleValueError,
+                              every(2).months.at, '15-10:0')
+            self.assertRaises(ScheduleValueError,
+                              every(2).months.at, '5-23:00')
 
     def test_next_run_time(self):
         with mock_datetime(2010, 1, 6, 12, 15):

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -258,6 +258,10 @@ class SchedulerTests(unittest.TestCase):
             assert every().month.at('04-12:40:30').do(mock_job).next_run.month == 2
             assert every().month.at('19-12:40:30').do(mock_job).next_run.day == 19
             assert every().month.at('19-12:40:30').do(mock_job).next_run.month == 1
+        with mock_datetime(2010, 2, 6, 12, 20, 30):
+            mock_job = make_mock_job()
+            assert every().month.at('31-12:40:30').do(mock_job).next_run.day == 28
+            assert every().month.at('31-12:40:30').do(mock_job).next_run.month == 2
 
         # Test that the monthly scheduler creates correct next_run dates
         with mock_datetime(2010, 1, 6, 12, 20, 30):
@@ -270,6 +274,25 @@ class SchedulerTests(unittest.TestCase):
         with mock_datetime(2010, 3, 4, 12, 40, 30):
             scheduler.run_pending()
             assert scheduler.jobs[0].next_run.month == 4
+
+        # Test the correct treatment of End of Month dates
+        with mock_datetime(2010, 1, 1, 12, 20, 30):
+            mock_job = make_mock_job()
+            scheduler = schedule.Scheduler()
+            scheduler.every().month.at('31-12:40:30').do(mock_job)
+        with mock_datetime(2010, 1, 31, 12, 40, 30):
+            scheduler.run_pending()
+            assert scheduler.jobs[0].next_run.month == 2
+            assert scheduler.jobs[0].next_run.day == 28
+        with mock_datetime(2010, 2, 28, 12, 40, 30):
+            scheduler.run_pending()
+            assert scheduler.jobs[0].next_run.month == 3
+            assert scheduler.jobs[0].next_run.day == 31
+        with mock_datetime(2010, 3, 31, 12, 40, 30):
+            scheduler.run_pending()
+            assert scheduler.jobs[0].next_run.month == 4
+            assert scheduler.jobs[0].next_run.day == 30
+
 
         # test invalid time format
         with mock_datetime(2010, 1, 6, 12, 20, 30):
@@ -305,6 +328,20 @@ class SchedulerTests(unittest.TestCase):
             scheduler.run_pending()
             assert scheduler.jobs[0].next_run.month == 5
             assert scheduler.jobs[0].next_run.year == 2011
+
+        # Test the correct treatment of End of Month dates
+        with mock_datetime(2010, 1, 1, 12, 20, 30):
+            mock_job = make_mock_job()
+            scheduler = schedule.Scheduler()
+            scheduler.every(3).months.at('30-12:40:30').do(mock_job)
+        with mock_datetime(2010, 1, 30, 12, 40, 30):
+            scheduler.run_pending()
+            assert scheduler.jobs[0].next_run.month == 4
+            assert scheduler.jobs[0].next_run.day == 30
+        with mock_datetime(2010, 4, 30, 12, 40, 30):
+            scheduler.run_pending()
+            assert scheduler.jobs[0].next_run.month == 7
+            assert scheduler.jobs[0].next_run.day == 30
 
         # test invalid time format
         with mock_datetime(2010, 1, 6, 12, 20, 30):

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -110,6 +110,15 @@ class SchedulerTests(unittest.TestCase):
         self.assertRaises(ScheduleValueError, job_instance.at, "0:61:0")
         self.assertRaises(ScheduleValueError, job_instance.at, "0:0:61")
 
+        # test a valid unit with invalid hours/minutes
+        job_instance.unit = "days"
+        self.assertRaises(ScheduleValueError, job_instance.at, "24:00")
+        self.assertRaises(ScheduleValueError, job_instance.at, "00:61")
+
+        # test invalid time format
+        self.assertRaises(ScheduleValueError, job_instance.at, "24:0")
+        self.assertRaises(ScheduleValueError, job_instance.at, "0:61")
+
         # test (very specific) seconds with unspecified start_day
         job_instance.unit = "seconds"
         job_instance.at_time = datetime.datetime.now()


### PR DESCRIPTION
Developed monthly periodicity functionality.

Monthly periodicity always need to have defined 'at("DD-HH:MM:SS")' or 'at("DD-HH:MM")', where "DD" is the day of the month it should run.
If "DD"=31 the periodic job will run the last day on the month.

Other exceptions related to end of month dates or February special case are controlled, at least as far as I've been able to check.
