### PR TITLE
Change logging level to debug

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -106,8 +106,8 @@ class Scheduler(object):
 
         :param delay_seconds: A delay added between every executed job
         """
-        logger.info('Running *all* %i jobs with %is delay inbetween',
-                    len(self.jobs), delay_seconds)
+        logger.debug('Running *all* %i jobs with %is delay inbetween',
+                     len(self.jobs), delay_seconds)
         for job in self.jobs[:]:
             self._run_job(job)
             time.sleep(delay_seconds)
@@ -481,7 +481,7 @@ class Job(object):
 
         :return: The return value returned by the `job_func`
         """
-        logger.info('Running job %s', self)
+        logger.debug('Running job %s', self)
         ret = self.job_func()
         self.last_run = datetime.datetime.now()
         self._schedule_next_run()


### PR DESCRIPTION
Currently schedule is printing it's log using `INFO` level, for most server side applications, users have a lot logs by his own. And the logs which schedule produces caused a lot of noises.

I'm writing a library which using schedule behind the sense, so I think as a library, I should not modify users' log config (consider if I diabled schedule's logger, but some user used it for his own). So I think the best solution is change schedule's log level to DEBUG. And this behavior is common for library, such as urllib3 (which the famouse requests uses):

https://github.com/urllib3/urllib3/search?q=logger.debug&unscoped_q=logger.debug
