### PR TITLE
Add timezone support without dependency

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,3 +17,4 @@ Thanks to all the wonderful folks who have contributed to schedule over the year
 - gilbsgilbs <https://github.com/gilbsgilbs>
 - Nathan Wailes <https://github.com/NathanWailes>
 - Connor Skees <https://github.com/ConnorSkees>
+- yifeikong <https://github.com/yifeikong>

--- a/FAQ.rst
+++ b/FAQ.rst
@@ -86,7 +86,12 @@ Run the scheduler in a separate thread. Mrwhick wrote up a nice solution in to t
 Does schedule support timezones?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Vanilla schedule doesn't support timezones at the moment. If you need this functionality please check out @imiric's work `here <https://github.com/dbader/schedule/pull/16>`__. He added timezone support to schedule using python-dateutil.
+Yes. Use the `timezone` method to set what timezone you would like to use.
+
+.. code-block:: python
+
+    # set job to run at midnight of GMT+8
+    schedule.timezone("+0800").every().day.at("00:00").do(job)
 
 What if my task throws an exception?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,7 @@ Features
 - Very lightweight and no external dependencies.
 - Excellent test coverage.
 - Tested on Python 2.7, 3.5, and 3.6
+- Timezone support.
 
 Usage
 -----
@@ -49,6 +50,7 @@ Usage
     schedule.every().monday.do(job)
     schedule.every().wednesday.at("13:15").do(job)
     schedule.every().minute.at(":17").do(job)
+    schedule.timezone("+0800").every().day.at("00:00").do(job)
 
     while True:
         schedule.run_pending()


### PR DESCRIPTION
You can now set timezone of when to run your job!

```
schedule.timezone("+0800").every().day.at("00:00").do(job)
```

This feature is totally opt-in. If you do not use timezone, nothing has been changed, it's still the same old way.

```
schedule.every().day.at("00:00").do(job)
```

This PR does not add any dependency.