### PR TITLE
Support human readable expression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ dist
 build
 eggs
 parts
-bin
 var
 sdist
 develop-eggs

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,20 @@ Usage
     schedule.every().wednesday.at("13:15").do(job)
     schedule.every().minute.at(":17").do(job)
 
+    # or use schedule expression
+    schedule.when("every 10 minutes").do(job)
+    schedule.when("every hour").do(job)
+    schedule.when("every day at 10:30").do(job)
+    schedule.when("every 5 to 10 minutes").do(job)
+    schedule.when("every monday").do(job)
+    schedule.when("every wednesday at 13:15").do(job)
+    schedule.when("every minute at :17").do(job)
+
+    # or use decorator to register job(without arguments)
+    @schedule.when("every 10 minutes")
+    def another_job():
+        print("I'm working on another job...")
+
     while True:
         schedule.run_pending()
         time.sleep(1)

--- a/bin/schedule
+++ b/bin/schedule
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# vi:ft=python
+
+
+"""
+This is a simple command like `cron`.
+
+The default configuration file is /etc/schedule, syntax goes like:
+
+    # line starts with # is comment
+    every 60 minutes, echo "wubba lubba dub dub"
+    # backup database every day at midnight
+    every day at 00:00, mysqldump -u backup
+    # redirect logs so you can see them
+    every minute, do_some_magic >> /some/output/file 2>&1
+"""
+
+import argparse
+import time
+import sys
+
+import schedule
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-f", "--file", default="/etc/schedule",
+                    help="configuration file to use")
+parser.add_argument("-t", "--test", action="store_true",
+                    help="test configuration and exit")
+args = parser.parse_args()
+
+with open(args.file) as f:
+    schedule_lines = f.read()
+
+for line in schedule_lines.split("\n"):
+    # ignore comments
+    if line.startswith("#"):
+        continue
+    # ignore empty lines
+    if not line.strip():
+        continue
+    try:
+        expr, command = line.split(",", 1)
+    except ValueError:
+        print("line '%s' is not valid" % line)
+        sys.exit(-1)
+
+    if not args.test:
+        schedule.when(expr).run_command(command, shell=True)
+
+while True:
+    try:
+        schedule.run_pending()
+        time.sleep(1)
+    except KeyboardInterrupt:
+        break

--- a/schedule-example
+++ b/schedule-example
@@ -1,0 +1,4 @@
+# line starts with # is comment
+every 5 seconds, echo "wubba lubba dub dub"
+# line starts with # is comment
+every 10 seconds, date

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -46,6 +46,7 @@ import functools
 import logging
 import random
 import re
+import subprocess
 import time
 
 logger = logging.getLogger('schedule')
@@ -519,6 +520,9 @@ class Job(object):
         self._schedule_next_run()
         self.scheduler.jobs.append(self)
         return self
+
+    def run_command(self, command, shell=False):
+        return self.do(subprocess.run, command, shell=shell)
 
     @property
     def should_run(self):

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     license='MIT',
     author='Daniel Bader',
     author_email='mail@dbader.org',
+    scripts=['bin/schedule'],
     url='https://github.com/dbader/schedule',
     download_url=SCHEDULE_DOWNLOAD_URL,
     keywords=[


### PR DESCRIPTION
In this PR, I add a `when` method to the Scheduler. With this function, we can store plain text schedule expression in text files, like what cron does with `/etc/crontab` file . A file using this idea may look like:

```
every day at 10:00, backup files
every day at 00:00, clean trash
every 60 minutes, go to toilet
```