### PR TITLE
Make idle_seconds return None when no jobs are scheduled

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -154,6 +154,7 @@ Time until the next execution
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Use ``schedule.idle_seconds()`` to get the number of seconds until the next job is scheduled to run.
 The returned value is negative if the next scheduled jobs was scheduled to run in the past.
+Returns ``None`` if no jobs are scheduled.
 
 .. code-block:: python
 

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -167,8 +167,11 @@ class Scheduler(object):
     def idle_seconds(self):
         """
         :return: Number of seconds until
-                 :meth:`next_run <Scheduler.next_run>`.
+                 :meth:`next_run <Scheduler.next_run>`
+                 or None if no jobs are scheduled
         """
+        if not self.next_run:
+            return None
         return (self.next_run - datetime.datetime.now()).total_seconds()
 
 

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -433,6 +433,7 @@ class SchedulerTests(unittest.TestCase):
 
     def test_idle_seconds(self):
         assert schedule.next_run() is None
+        assert schedule.idle_seconds() is None
 
         mock_job = make_mock_job()
         with mock_datetime(2020, 12, 9, 21, 46):
@@ -440,6 +441,7 @@ class SchedulerTests(unittest.TestCase):
             assert schedule.idle_seconds() == 60 * 60
             schedule.cancel_job(job)
             assert schedule.next_run() is None
+            assert schedule.idle_seconds() is None
 
     def test_cancel_job(self):
         def stop_job():


### PR DESCRIPTION
This PR is a continuation of #345. It ensures calling `.idle_seconds()` returns None when no jobs are scheduled. Docs and tests are added as well.

This change resolves below exception that happens when `.idle_seconds()` is called when no jobs are scheduled:
```
Traceback (most recent call last):                      
  File "/home/sijmen/projects/schedule/test.py", line 8, in <module>
    print(schedule.idle_seconds())
  File "/home/sijmen/projects/schedule/schedule/__init__.py", line 627, in idle_seconds
    return default_scheduler.idle_seconds
  File "/home/sijmen/projects/schedule/schedule/__init__.py", line 172, in idle_seconds
    return (self.next_run - datetime.datetime.now()).total_seconds()
TypeError: unsupported operand type(s) for -: 'NoneType' and 'datetime.datetime'
```