### PR TITLE
Improve docs of .at() method to better show allowed options

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -33,9 +33,9 @@ Run a job every x minute
     # If current time is 02:00, first execution is at 06:20:30
     schedule.every(5).hours.at("20:30").do(job)
 
-    # Run job every day at specific timestamp
+    # Run job every day at specific HH:MM and next HH:MM:SS
     schedule.every().day.at("10:30").do(job)
-    schedule.every().day.at("10:30").do(job)
+    schedule.every().day.at("10:30:42").do(job)
 
     # Run job on a specific day of the week
     schedule.every().monday.do(job)

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -383,12 +383,19 @@ class Job(object):
         """
         Specify a particular time that the job should be run at.
 
-        :param time_str: A string in one of the following formats: `HH:MM:SS`,
-            `HH:MM`,`:MM`, `:SS`. The format must make sense given how often
-            the job is repeating; for example, a job that repeats every minute
-            should not be given a string in the form `HH:MM:SS`. The difference
-            between `:MM` and `:SS` is inferred from the selected time-unit
-            (e.g. `every().hour.at(':30')` vs. `every().minute.at(':30')`).
+        :param time_str: A string in one of the following formats:
+
+            - For daily jobs -> `HH:MM:SS` or `HH:MM`
+            - For hourly jobs -> `MM:SS` or `:MM`
+            - For minute jobs -> `:SS`
+
+            The format must make sense given how often the job is
+            repeating; for example, a job that repeats every minute
+            should not be given a string in the form `HH:MM:SS`. The
+            difference between `:MM` and :SS` is inferred from the
+            selected time-unit (e.g. `every().hour.at(':30')` vs.
+            `every().minute.at(':30')`).
+
         :return: The invoked job instance
         """
         if (self.unit not in ('days', 'hours', 'minutes')


### PR DESCRIPTION
As discussed in #405, the documentation around the allowed time formats in `.at()` can be improved. This pr applies those changes.