### PR TITLE
Drop python 2.7 and 3.5, add python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -25,13 +25,6 @@ jobs:
         run: pip install tox tox-gh-actions
       - name: Tests
         run: tox
-      - name: Set up Python 3.8
-        # A recent version of coveralls is required for Github
-        # Actions support, which is only available for python3
-        if: matrix.python-version == '2.7'
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
       - name: Coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Python job scheduling for humans. Run Python functions (or any other callable) p
 - In-process scheduler for periodic jobs. No extra processes needed!
 - Very lightweight and no external dependencies.
 - Excellent test coverage.
-- Tested on Python 2.7, 3.5, and 3.6
+- Tested on Python and 3.6, 3.7, 3.8, 3.9
 
 Usage
 -----

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -26,12 +26,10 @@ It seems python can't find the schedule package. Let's check some common causes.
 
 Did you install schedule? If not, follow :doc:`installation`. Validate installation:
 
-* Did you install using pip? Run ``pip3 list | grep schedule``.
-* Did you install using apt? Run ``dpkg -l | grep python3-schedule``
+* Did you install using pip? Run ``pip3 list | grep schedule``. This should return ``schedule   0.6.0`` (or a higher version number)
+* Did you install using apt? Run ``dpkg -l | grep python3-schedule``. This should return something along the lines of ``python3-schedule     0.3.2-1.1     Job scheduling for humans (Python 3)`` (or a higher version number)
 
-These should return
-
-Are you using the same Python version to install Schedule and execute your code?
+Are you used python 3 to install Schedule, and are running the script using python 3?
 For example, if you installed schedule using a version of pip that uses Python 2, and your code runs in Python 3, the package won't be found.
 In this case the solution is to install Schedule using pip3: ``pip3 install schedule``.
 
@@ -39,7 +37,7 @@ Are you using virtualenv? Check that you are running the script inside the same 
 
 Is this problem occurring when running the program from inside and IDE like PyCharm or VSCode?
 Try to run your program from a commandline outside of the IDE.
-If it works there, the problem is in your IDE configuration.
+If it works there, the problem is with your IDE configuration.
 It might be that your IDE uses a different Python interpreter installation.
 
 Still having problems? Use Google and StackOverflow before submitting an issue.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ Python job scheduling for humans. Run Python functions (or any other callable) p
 - In-process scheduler for periodic jobs. No extra processes needed!
 - Very lightweight and no external dependencies.
 - Excellent test coverage.
-- Tested on Python 2.7, 3.5, and 3.6
+- Tested on Python 3.6, 3.7, 3.8 and 3.9
 
 
 :doc:`Example <examples>`

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,7 +6,9 @@ Python version support
 ######################
 
 We recommend using the latest version of Python.
-Schedule is tested on Python 2.7, 3.5, and 3.6
+Schedule is tested on Python 3.6, 3.7, 3.8 and 3.9
+
+Want to use Schedule on Python 2.7 or 3.5? Use version 0.6.0.
 
 
 Dependencies

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -15,7 +15,7 @@ Features:
     - A simple to use API for scheduling jobs.
     - Very lightweight and no external dependencies.
     - Excellent test coverage.
-    - Tested on Python 2.7, 3.5 and 3.6
+    - Tested on Python 3.6, 3.7, 3.8, 3.9
 
 Usage:
     >>> import schedule
@@ -37,10 +37,7 @@ Usage:
 [2] https://github.com/Rykian/clockwork
 [3] https://adam.herokuapp.com/past/2010/6/30/replace_cron_with_clockwork/
 """
-try:
-    from collections.abc import Hashable
-except ImportError:
-    from collections import Hashable
+from collections.abc import Hashable
 import datetime
 import functools
 import logging
@@ -472,13 +469,7 @@ class Job(object):
         :return: The invoked job instance
         """
         self.job_func = functools.partial(job_func, *args, **kwargs)
-        try:
-            functools.update_wrapper(self.job_func, job_func)
-        except AttributeError:
-            # job_funcs already wrapped by functools.partial won't have
-            # __name__, __module__ or __doc__ and the update_wrapper()
-            # call will fail.
-            pass
+        functools.update_wrapper(self.job_func, job_func)
         self._schedule_next_run()
         self.scheduler.jobs.append(self)
         return self

--- a/setup.py
+++ b/setup.py
@@ -44,13 +44,15 @@ setup(
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
+        'Development Status :: 5 - Production/Stable',
+        'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Natural Language :: English',
     ],
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
+    python_requires='>=3.6',
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,14 @@
 [tox]
-envlist = py27, py3{5,6,7,8}, docs
+envlist = py3{6,7,8,9}, docs
 skip_missing_interpreters = true
 
 
 [gh-actions]
 python =
-    2.7: py27
-    3.5: py35
     3.6: py36
     3.7: py37
     3.8: py38
+    3.9: py39
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
As discussed in #409 and #412, this library won't be supporting python versions that have reached end of life from version 1.0.0 onwards. This PR drops support for python 2.7 and 3.5, and adds support for python 3.9.

Closes #409 