### PR TITLE
Added way to retrieve existing jobs per tags.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -21,3 +21,4 @@ Thanks to all the wonderful folks who have contributed to schedule over the year
 - aisk <https://github.com/aisk>
 - MichaelCorleoneLi <https://github.com/MichaelCorleoneLi>
 - SijmenHuizenga <https://github.com/SijmenHuizenga>
+- Skenvy <https://github.com/skenvy>

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -115,6 +115,22 @@ To retrieve all jobs from the scheduler, use ``schedule.get_jobs()``
     all_jobs = schedule.get_jobs()
 
 
+Cancel all jobs
+~~~~~~~~~~~~~~~
+To remove all jobs from the scheduler, use ``schedule.clear()``
+
+.. code-block:: python
+
+    import schedule
+
+    def greet(name):
+        print('Hello {}'.format(name))
+
+    schedule.every().second.do(greet)
+
+    schedule.clear()
+
+
 Get several jobs, filtered by tags
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -137,24 +153,8 @@ You can retrieve a group of jobs from the scheduler, selecting them by a unique 
 Will return a list of every job tagged as ``friend``.
 
 
-Cancel all jobs
-~~~~~~~~~~~~~~~
-To remove all jobs from the scheduler, use ``schedule.clear()``
-
-.. code-block:: python
-
-    import schedule
-
-    def greet(name):
-        print('Hello {}'.format(name))
-
-    schedule.every().second.do(greet)
-
-    schedule.clear()
-
-
-Cancel several jobs at once
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Cancel several jobs, filtered by tags
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can cancel the scheduling of a group of jobs selecting them by a unique identifier.
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -99,6 +99,44 @@ Return ``schedule.CancelJob`` from a job to remove it from the scheduler.
         time.sleep(1)
 
 
+Get all jobs
+~~~~~~~~~~~~
+To retrieve all jobs from the scheduler, use ``schedule.get_jobs()``
+
+.. code-block:: python
+
+    import schedule
+
+    def hello():
+        print('Hello world')
+
+    schedule.every().second.do(hello)
+
+    all_jobs = schedule.get_jobs()
+
+
+Get several jobs, filtered by tags
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can retrieve a group of jobs from the scheduler, selecting them by a unique identifier.
+
+.. code-block:: python
+
+    import schedule
+
+    def greet(name):
+        print('Hello {}'.format(name))
+
+    schedule.every().day.do(greet, 'Andrea').tag('daily-tasks', 'friend')
+    schedule.every().hour.do(greet, 'John').tag('hourly-tasks', 'friend')
+    schedule.every().hour.do(greet, 'Monica').tag('hourly-tasks', 'customer')
+    schedule.every().day.do(greet, 'Derek').tag('daily-tasks', 'guest')
+
+    friends = schedule.get_jobs('friend')
+
+Will return a list of every job tagged as ``friend``.
+
+
 Cancel all jobs
 ~~~~~~~~~~~~~~~
 To remove all jobs from the scheduler, use ``schedule.clear()``
@@ -135,6 +173,7 @@ You can cancel the scheduling of a group of jobs selecting them by a unique iden
     schedule.clear('daily-tasks')
 
 Will prevent every job tagged as ``daily-tasks`` from running again.
+
 
 Run a job at random intervals
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -14,6 +14,7 @@ Main Interface
 .. autofunction:: every
 .. autofunction:: run_pending
 .. autofunction:: run_all
+.. autofunction:: get_jobs
 .. autofunction:: clear
 .. autofunction:: cancel_job
 .. autofunction:: next_run

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -109,6 +109,19 @@ class Scheduler(object):
             self._run_job(job)
             time.sleep(delay_seconds)
 
+    def get_jobs(self, tag=None):
+        """
+        Gets scheduled jobs marked with the given tag, or all jobs
+        if tag is omitted.
+
+        :param tag: An identifier used to identify a subset of
+                    jobs to retrieve
+        """
+        if tag is None:
+            return self.jobs[:]
+        else:
+            return [job for job in self.jobs if tag in job.tags]
+
     def clear(self, tag=None):
         """
         Deletes scheduled jobs marked with the given tag, or all jobs
@@ -597,6 +610,13 @@ def run_all(delay_seconds=0):
     :data:`default scheduler instance <default_scheduler>`.
     """
     default_scheduler.run_all(delay_seconds=delay_seconds)
+
+
+def get_jobs(tag=None):
+    """Calls :meth:`get_jobs <Scheduler.get_jobs>` on the
+    :data:`default scheduler instance <default_scheduler>`.
+    """
+    return default_scheduler.get_jobs(tag)
 
 
 def clear(tag=None):

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -561,30 +561,22 @@ class SchedulerTests(unittest.TestCase):
         every().second.do(make_mock_job()).tag('job1', 'tag1')
         every().second.do(make_mock_job()).tag('job2', 'tag2', 'tag4')
         every().second.do(make_mock_job()).tag('job3', 'tag3', 'tag4')
+
         # Test None input yields all 3
         jobs = schedule.get_jobs()
         assert len(jobs) == 3
-        all_tags = jobs[0].tags.copy()
-        all_tags.update(jobs[1].tags, jobs[2].tags)
-        jobs_names = [name for name in all_tags if 'job' in name]
-        assert set(jobs_names) == set(['job1', 'job2', 'job3'])
+        assert {'job1', 'job2', 'job3'}.issubset({*jobs[0].tags, *jobs[1].tags, *jobs[2].tags})
+
         # Test each 1:1 tag:job
         jobs = schedule.get_jobs('tag1')
         assert len(jobs) == 1
         assert 'job1' in jobs[0].tags
-        jobs = schedule.get_jobs('tag2')
-        assert len(jobs) == 1
-        assert 'job2' in jobs[0].tags
-        jobs = schedule.get_jobs('tag3')
-        assert len(jobs) == 1
-        assert 'job3' in jobs[0].tags
+
         # Test multiple jobs found.
         jobs = schedule.get_jobs('tag4')
         assert len(jobs) == 2
-        all_tags = jobs[0].tags.copy()
-        all_tags.update(jobs[1].tags)
-        jobs_names = [name for name in all_tags if 'job' in name]
-        assert set(jobs_names) == set(['job2', 'job3'])
+        assert 'job1' not in {*jobs[0].tags, *jobs[1].tags}
+
         # Test no tag.
         jobs = schedule.get_jobs('tag5')
         assert len(jobs) == 0

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -565,7 +565,8 @@ class SchedulerTests(unittest.TestCase):
         # Test None input yields all 3
         jobs = schedule.get_jobs()
         assert len(jobs) == 3
-        assert {'job1', 'job2', 'job3'}.issubset({*jobs[0].tags, *jobs[1].tags, *jobs[2].tags})
+        assert {'job1', 'job2', 'job3'}\
+            .issubset({*jobs[0].tags, *jobs[1].tags, *jobs[2].tags})
 
         # Test each 1:1 tag:job
         jobs = schedule.get_jobs('tag1')


### PR DESCRIPTION
In making extensive use of multiple `tags` on each `Job` (that define multiple configuration settings that define what that job does, as well as manufactured guids) I've encountered the following **need**/*nice-to-have*.

> I'd like to be able to use `schedule.get_jobs(some_tag) ` to retrieve an `iterable` of `Job` instances which I can then use to log/report on the other tags that have been attached. 

If I have functionality that finds `Job`'s that can be periodically removed by comparing against a table of changing guids, but I've used the `tags` to hold the relevant information that I would like to `log` to have a *human readable history* of what `Job`'s were removed, I need a way to get `Job`'s by `tags`. 

The alternative would be to have the `Scheduler.clear(...)` return the list of jobs that it had removed.