### PR TITLE
New function for returning a set of pattern matched tags

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -75,7 +75,27 @@ To remove a job from the scheduler, use the ``schedule.cancel_job(job)`` method
         print('Hello world')
 
     job = schedule.every().day.at('22:30').do(some_task)
-    shcedule.cancel_job(job)
+    schedule.cancel_job(job)
+
+
+Get a set of tags by pattern matching
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+To get a set of tags which match a regex pattern, use the ``schedule.get_tags(tag_regex)`` method
+
+.. code-block:: python
+
+    import schedule
+
+    def hello_world():
+        print('Hello world')
+
+    def greet(name):
+        print('Hello {}'.format(name))
+
+    job = schedule.every(10).seconds.do(hello_world).tag('job_1', 'task_hello', 'user_None')
+    job = schedule.every(10).seconds.do(greet, 'Jesse').tag('job_2', 'task_greet', 'user_Jesse')
+    job = schedule.every(10).seconds.do(greet, 'James').tag('job_2', 'task_greet', 'user_James')
+    schedule.get_tags("^task_")  # To get all tags that start with "task_"
 
 
 Run a job once

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -16,6 +16,7 @@ Main Interface
 .. autofunction:: run_all
 .. autofunction:: clear
 .. autofunction:: cancel_job
+.. autofunction:: get_tags
 .. autofunction:: next_run
 .. autofunction:: idle_seconds
 

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -133,6 +133,19 @@ class Scheduler(object):
         except ValueError:
             pass
 
+    def get_tags(self, tag_regex=None):
+        """
+        Deletes scheduled jobs marked with the given tag, or all jobs
+        if tag is omitted.
+
+        :param tag: An identifier used to identify a subset of
+                    jobs to delete
+        """
+        if tag_regex is None:
+            tag_regex = ""
+        return set([tag for job in self.jobs for tag in job.tags
+                    if re.search(tag_regex, str(tag)) is not None])
+
     def every(self, interval=1):
         """
         Schedule a new periodic job.
@@ -611,6 +624,13 @@ def cancel_job(job):
     :data:`default scheduler instance <default_scheduler>`.
     """
     default_scheduler.cancel_job(job)
+
+
+def get_tags(tag_regex=None):
+    """Calls :meth:`get_tags <Scheduler.get_tags>` on the
+    :data:`default scheduler instance <default_scheduler>`.
+    """
+    return default_scheduler.get_tags(tag_regex=tag_regex)
 
 
 def next_run():

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -550,6 +550,19 @@ class SchedulerTests(unittest.TestCase):
         schedule.run_all()
         assert len(schedule.jobs) == 0
 
+    def test_get_tags(self):
+        every().second.do(make_mock_job()).tag('T1', 'isA')
+        every().second.do(make_mock_job()).tag('T2', 'isA')
+        every().second.do(make_mock_job()).tag('T3', 'isB')
+        # Test get all
+        assert schedule.get_tags() == set(['T1', 'T2', 'T3', 'isA', 'isB'])
+        # Test simple string
+        assert schedule.get_tags("T") == set(['T1', 'T2', 'T3'])
+        # Test regex token
+        assert schedule.get_tags("^is") == set(['isA', 'isB'])
+        # Test no return
+        assert schedule.get_tags("^Q") == set()
+
     def test_tag_type_enforcement(self):
         job1 = every().second.do(make_mock_job(name='job1'))
         self.assertRaises(TypeError, job1.tag, {})


### PR DESCRIPTION
As per the example added to the rst, if I am using tags to identify metadata about jobs with multiple fields, if I am using a seperate mechanism to keep track of which jobs need to be added or removed, I would like to include functionality that would utilise this new function to return to me a list of tags that define specific metadata to then update jobs in another scheduler to keep them in sync with the main scheduler's jobs.