### PR TITLE
Update GitHub button in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,6 +139,7 @@ html_theme_options = {
     'github_repo': 'schedule',
     'github_banner': True,
     'github_button': True,
+    'github_type': 'star',
     'show_related': False
 }
 


### PR DESCRIPTION
A very important cosmetic change ;-)

Before:
![Screen Shot 2021-02-01 at 10 29 33 AM](https://user-images.githubusercontent.com/306708/106501788-664b5c00-6478-11eb-92c6-e3f85855eee7.png)

After:
![Screen Shot 2021-02-01 at 10 29 36 AM](https://user-images.githubusercontent.com/306708/106501805-69dee300-6478-11eb-807c-e67259f823e9.png)
