### PR TITLE
Fix str of job when there is no __name__

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -223,6 +223,11 @@ class Job(object):
         return self.next_run < other.next_run
 
     def __str__(self):
+        if hasattr(self.job_func, '__name__'):
+            job_func_name = self.job_func.__name__
+        else:
+            job_func_name = repr(self.job_func)
+
         return (
             "Job(interval={}, "
             "unit={}, "
@@ -231,7 +236,7 @@ class Job(object):
             "kwargs={})"
         ).format(self.interval,
                  self.unit,
-                 self.job_func.__name__,
+                 job_func_name,
                  self.job_func.args,
                  self.job_func.keywords)
 

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -430,7 +430,7 @@ class SchedulerTests(unittest.TestCase):
         assert len(str(every().minute.do(lambda: 1))) > 1
         assert len(str(every().day.at('10:30').do(lambda: 1))) > 1
 
-    def test_to_string_functools_partial_job_func(self):
+    def test_repr_functools_partial_job_func(self):
         def job_fun(arg):
             pass
         job_fun = functools.partial(job_fun, 'foo')
@@ -438,6 +438,15 @@ class SchedulerTests(unittest.TestCase):
         assert 'functools.partial' in job_repr
         assert 'bar=True' in job_repr
         assert 'somekey=23' in job_repr
+
+    def test_to_string_functools_partial_job_func(self):
+        def job_fun(arg):
+            pass
+        job_fun = functools.partial(job_fun, 'foo')
+        job_str = str(every().minute.do(job_fun, bar=True, somekey=23))
+        assert 'functools.partial' in job_str
+        assert 'bar=True' in job_str
+        assert 'somekey=23' in job_str
 
     def test_run_pending(self):
         """Check that run_pending() runs pending jobs.


### PR DESCRIPTION
Partial functions for example do not have a `__name__`, so they need the same treatment in `__str__` as in `__repr__` in order to show   name-like thing.

Also added tests to stop this from happening again.