### PR TITLE
Fixture/Add more self explanatory message on IntervalError exception

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -364,7 +364,9 @@ class Job(object):
     def monday(self):
         if self.interval != 1:
             raise IntervalError(
-                "Scheduling jobs every 2 or more weeks is not supported"
+                "Scheduling .monday() jobs is only allowed for weekly jobs. "
+                "Using .monday() on a job scheduled to run every 2 or more weeks "
+                "is not supported."
             )
         self.start_day = "monday"
         return self.weeks
@@ -373,7 +375,9 @@ class Job(object):
     def tuesday(self):
         if self.interval != 1:
             raise IntervalError(
-                "Scheduling jobs every 2 or more weeks is not supported"
+                "Scheduling .tuesday() jobs is only allowed for weekly jobs. "
+                "Using .tuesday() on a job scheduled to run every 2 or more weeks "
+                "is not supported."
             )
         self.start_day = "tuesday"
         return self.weeks
@@ -382,7 +386,9 @@ class Job(object):
     def wednesday(self):
         if self.interval != 1:
             raise IntervalError(
-                "Scheduling jobs every 2 or more weeks is not supported"
+                "Scheduling .wednesday() jobs is only allowed for weekly jobs. "
+                "Using .wednesday() on a job scheduled to run every 2 or more weeks "
+                "is not supported."
             )
         self.start_day = "wednesday"
         return self.weeks
@@ -391,7 +397,9 @@ class Job(object):
     def thursday(self):
         if self.interval != 1:
             raise IntervalError(
-                "Scheduling jobs every 2 or more weeks is not supported"
+                "Scheduling .thursday() jobs is only allowed for weekly jobs. "
+                "Using .thursday() on a job scheduled to run every 2 or more weeks "
+                "is not supported."
             )
         self.start_day = "thursday"
         return self.weeks
@@ -400,7 +408,9 @@ class Job(object):
     def friday(self):
         if self.interval != 1:
             raise IntervalError(
-                "Scheduling jobs every 2 or more weeks is not supported"
+                "Scheduling .friday() jobs is only allowed for weekly jobs. "
+                "Using .friday() on a job scheduled to run every 2 or more weeks "
+                "is not supported."
             )
         self.start_day = "friday"
         return self.weeks
@@ -409,7 +419,9 @@ class Job(object):
     def saturday(self):
         if self.interval != 1:
             raise IntervalError(
-                "Scheduling jobs every 2 or more weeks is not supported"
+                "Scheduling .saturday() jobs is only allowed for weekly jobs. "
+                "Using .saturday() on a job scheduled to run every 2 or more weeks "
+                "is not supported."
             )
         self.start_day = "saturday"
         return self.weeks
@@ -418,7 +430,9 @@ class Job(object):
     def sunday(self):
         if self.interval != 1:
             raise IntervalError(
-                "Scheduling jobs every 2 or more weeks is not supported"
+                "Scheduling .sunday() jobs is only allowed for weekly jobs. "
+                "Using .sunday() on a job scheduled to run every 2 or more weeks "
+                "is not supported."
             )
         self.start_day = "sunday"
         return self.weeks

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -363,49 +363,63 @@ class Job(object):
     @property
     def monday(self):
         if self.interval != 1:
-            raise IntervalError("Use mondays instead of monday")
+            raise IntervalError(
+                "Scheduling jobs every 2 or more weeks is not supported"
+            )
         self.start_day = "monday"
         return self.weeks
 
     @property
     def tuesday(self):
         if self.interval != 1:
-            raise IntervalError("Use tuesdays instead of tuesday")
+            raise IntervalError(
+                "Scheduling jobs every 2 or more weeks is not supported"
+            )
         self.start_day = "tuesday"
         return self.weeks
 
     @property
     def wednesday(self):
         if self.interval != 1:
-            raise IntervalError("Use wednesdays instead of wednesday")
+            raise IntervalError(
+                "Scheduling jobs every 2 or more weeks is not supported"
+            )
         self.start_day = "wednesday"
         return self.weeks
 
     @property
     def thursday(self):
         if self.interval != 1:
-            raise IntervalError("Use thursdays instead of thursday")
+            raise IntervalError(
+                "Scheduling jobs every 2 or more weeks is not supported"
+            )
         self.start_day = "thursday"
         return self.weeks
 
     @property
     def friday(self):
         if self.interval != 1:
-            raise IntervalError("Use fridays instead of friday")
+            raise IntervalError(
+                "Scheduling jobs every 2 or more weeks is not supported"
+            )
         self.start_day = "friday"
         return self.weeks
 
     @property
     def saturday(self):
         if self.interval != 1:
-            raise IntervalError("Use saturdays instead of saturday")
+            raise IntervalError(
+                "Scheduling jobs every 2 or more weeks is not supported"
+            )
         self.start_day = "saturday"
         return self.weeks
 
     @property
     def sunday(self):
         if self.interval != 1:
-            raise IntervalError("Use sundays instead of sunday")
+            raise IntervalError(
+                "Scheduling jobs every 2 or more weeks is not supported"
+            )
         self.start_day = "sunday"
         return self.weeks
 

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -84,31 +84,66 @@ class SchedulerTests(unittest.TestCase):
         with self.assertRaises(IntervalError):
             job_instance.week
         with self.assertRaisesRegex(
-            IntervalError, "Scheduling jobs every 2 or more weeks is not supported"
+            IntervalError,
+            (
+                r"Scheduling \.monday\(\) jobs is only allowed for weekly jobs\. "
+                r"Using \.monday\(\) on a job scheduled to run every 2 or more "
+                r"weeks is not supported\."
+            ),
         ):
             job_instance.monday
         with self.assertRaisesRegex(
-            IntervalError, "Scheduling jobs every 2 or more weeks is not supported"
+            IntervalError,
+            (
+                r"Scheduling \.tuesday\(\) jobs is only allowed for weekly jobs\. "
+                r"Using \.tuesday\(\) on a job scheduled to run every 2 or more "
+                r"weeks is not supported\."
+            ),
         ):
             job_instance.tuesday
         with self.assertRaisesRegex(
-            IntervalError, "Scheduling jobs every 2 or more weeks is not supported"
+            IntervalError,
+            (
+                r"Scheduling \.wednesday\(\) jobs is only allowed for weekly jobs\. "
+                r"Using \.wednesday\(\) on a job scheduled to run every 2 or more "
+                r"weeks is not supported\."
+            ),
         ):
             job_instance.wednesday
         with self.assertRaisesRegex(
-            IntervalError, "Scheduling jobs every 2 or more weeks is not supported"
+            IntervalError,
+            (
+                r"Scheduling \.thursday\(\) jobs is only allowed for weekly jobs\. "
+                r"Using \.thursday\(\) on a job scheduled to run every 2 or more "
+                r"weeks is not supported\."
+            ),
         ):
             job_instance.thursday
         with self.assertRaisesRegex(
-            IntervalError, "Scheduling jobs every 2 or more weeks is not supported"
+            IntervalError,
+            (
+                r"Scheduling \.friday\(\) jobs is only allowed for weekly jobs\. "
+                r"Using \.friday\(\) on a job scheduled to run every 2 or more "
+                r"weeks is not supported\."
+            ),
         ):
             job_instance.friday
         with self.assertRaisesRegex(
-            IntervalError, "Scheduling jobs every 2 or more weeks is not supported"
+            IntervalError,
+            (
+                r"Scheduling \.saturday\(\) jobs is only allowed for weekly jobs\. "
+                r"Using \.saturday\(\) on a job scheduled to run every 2 or more "
+                r"weeks is not supported\."
+            ),
         ):
             job_instance.saturday
         with self.assertRaisesRegex(
-            IntervalError, "Scheduling jobs every 2 or more weeks is not supported"
+            IntervalError,
+            (
+                r"Scheduling \.sunday\(\) jobs is only allowed for weekly jobs\. "
+                r"Using \.sunday\(\) on a job scheduled to run every 2 or more "
+                r"weeks is not supported\."
+            ),
         ):
             job_instance.sunday
 

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -83,19 +83,33 @@ class SchedulerTests(unittest.TestCase):
             job_instance.day
         with self.assertRaises(IntervalError):
             job_instance.week
-        with self.assertRaises(IntervalError):
+        with self.assertRaisesRegex(
+            IntervalError, "Scheduling jobs every 2 or more weeks is not supported"
+        ):
             job_instance.monday
-        with self.assertRaises(IntervalError):
+        with self.assertRaisesRegex(
+            IntervalError, "Scheduling jobs every 2 or more weeks is not supported"
+        ):
             job_instance.tuesday
-        with self.assertRaises(IntervalError):
+        with self.assertRaisesRegex(
+            IntervalError, "Scheduling jobs every 2 or more weeks is not supported"
+        ):
             job_instance.wednesday
-        with self.assertRaises(IntervalError):
+        with self.assertRaisesRegex(
+            IntervalError, "Scheduling jobs every 2 or more weeks is not supported"
+        ):
             job_instance.thursday
-        with self.assertRaises(IntervalError):
+        with self.assertRaisesRegex(
+            IntervalError, "Scheduling jobs every 2 or more weeks is not supported"
+        ):
             job_instance.friday
-        with self.assertRaises(IntervalError):
+        with self.assertRaisesRegex(
+            IntervalError, "Scheduling jobs every 2 or more weeks is not supported"
+        ):
             job_instance.saturday
-        with self.assertRaises(IntervalError):
+        with self.assertRaisesRegex(
+            IntervalError, "Scheduling jobs every 2 or more weeks is not supported"
+        ):
             job_instance.sunday
 
         # test an invalid unit


### PR DESCRIPTION
As discussed here on the issue #433 , I've changed the code related to the error message in the exception to reflect what is causing the error. I believe also, since it's an interval problem, we could just put `Invalid interval value` or something more simples. It's up to you @SijmenHuizenga .