### PR TITLE
Split up Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   docs:
-    # Build docs separately to make visualise documentation
-    # problems separably in the PR overview
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -65,3 +63,29 @@ jobs:
         run: pip install tox
       - name: Check docs
         run: tox -e docs
+
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: pip install tox
+      - name: Check docs
+        run: tox -e docs
+
+  setuppy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: pip install tox
+      - name: Check docs
+        run: tox -e setuppy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,8 @@ jobs:
           python-version: 3.8
       - name: Install dependencies
         run: pip install tox
-      - name: Check docs
-        run: tox -e docs
+      - name: Check formatting
+        run: tox -e format
 
   setuppy:
     runs-on: ubuntu-latest

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -27,8 +27,9 @@ This project uses `black formatter <https://black.readthedocs.io/en/stable/>`_.
 To format the code, run:
 
 .. code-block:: bash
-
     black .
+    fadafsd
+    afsdafsd
 
 Make sure you use version 20.8b1 of black.
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -27,9 +27,8 @@ This project uses `black formatter <https://black.readthedocs.io/en/stable/>`_.
 To format the code, run:
 
 .. code-block:: bash
+
     black .
-    fadafsd
-    afsdafsd
 
 Make sure you use version 20.8b1 of black.
 

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -456,12 +456,6 @@ class Job(object):
 
     def at(self, time_str):
 
-
-
-
-
-
-
         """
         Specify a particular time that the job should be run at.
 

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -544,7 +544,7 @@ class Job(object):
 
     def until(
         self,
-        until_time: Union[datetime.datetime, datetime.timedelta, datetime.time, str]
+        until_time: Union[datetime.datetime, datetime.timedelta, datetime.time, str],
     ):
         """
         Schedule job to run until the specified moment.

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -455,6 +455,13 @@ class Job(object):
         return self
 
     def at(self, time_str):
+
+
+
+
+
+
+
         """
         Specify a particular time that the job should be run at.
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ changedir = docs
 deps = -rrequirements-dev.txt
 commands = sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
-[testenv:formatting]
+[testenv:format]
 deps = -rrequirements-dev.txt
 commands = black --check .
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{6,7,8,9}, docs
+envlist = py3{6,7,8,9}
 skip_missing_interpreters = true
 
 
@@ -13,16 +13,19 @@ python =
 [testenv]
 deps = -rrequirements-dev.txt
 commands =
-    py.test test_schedule.py --flake8 schedule -v --cov schedule --cov-report term-missing
-    python setup.py check --strict --metadata --restructuredtext
+    py.test test_schedule.py schedule -v --cov schedule --cov-report term-missing
     python -m mypy -p schedule
 
 [testenv:docs]
 changedir = docs
 deps = -rrequirements-dev.txt
-commands =
-    sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+commands = sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
-[flake8]
-max-line-length = 88
-extend-ignore = E203
+[testenv:formatting]
+deps = -rrequirements-dev.txt
+commands = black --check .
+
+[testenv:setuppy]
+deps = -rrequirements-dev.txt
+commands =
+    python setup.py check --strict --metadata --restructuredtext


### PR DESCRIPTION
Previously if he code has an formatting error, all tests fail. In this pr I'm trying to make format-checks, unit-test and documentation validation to be reported separately in Github Actions. 

Use `black check` instead of flake8 for format validation.

This is still work in progress. Suggestions are welcome :smile: 