### PR TITLE
removed a pitfall where a class field was being defined outside the init

### DIFF
--- a/test_schedule.py
+++ b/test_schedule.py
@@ -36,6 +36,7 @@ class mock_datetime(object):
         self.hour = hour
         self.minute = minute
         self.second = second
+        self.original_datetime = None
 
     def __enter__(self):
         class MockDate(datetime.datetime):


### PR DESCRIPTION
**The problem**
There was a class field being defined outside the class \_\_init\_\_
It might be problematic in some scenarios where the code tries to access the field before it is created. It also could hinder the understanding of the code due to the fact the class field definitions are scattered on the source instead of centralized into a single place.

This pitfall was detected automatically via Pylint, which triggered the warning code **W0201** which is described [here](https://vald-phoenix.github.io/pylint-errors/plerr/errors/classes/W0201.html)

**The solution**
Refactored the code to create the field on the \_\_init\_\_