### PR TITLE
Pin click to fix Github Actions formatting checks

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,5 @@ pytest-cov
 pytest-flake8
 Sphinx
 black==20.8b1
+click==8.0.4
 mypy


### PR DESCRIPTION
As seen [here](https://github.com/dbader/schedule/runs/5821238055?check_suite_focus=true) with error

```
ImportError: cannot import name '_unicodefun' from 'click' (/home/runner/work/schedule/schedule/.tox/format/lib/python3.8/site-packages/click/__init__.py)
```

This error is reproducible by running:
```
tox -e format
```

As described [here](https://github.com/psf/black/issues/2964) we must pin `click` to resolve this error.

Alternatively we could upgrade Black to a newer version, but this requires some reformatting. I am hoping to do this in a separate pr.