### PR TITLE
Fix/sphinx default version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ release = u"1.1.0"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "EN"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ Pygments
 pytest
 pytest-cov
 pytest-flake8
-Sphinx<=4.5.0
+Sphinx
 black==20.8b1
 click==8.0.4
 mypy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ Pygments
 pytest
 pytest-cov
 pytest-flake8
-Sphinx
+Sphinx<=4.5.0
 black==20.8b1
 click==8.0.4
 mypy


### PR DESCRIPTION
After Sphinx 5.0, the Sphinx config `"language = None"` does not work ,change it to `language = "EN"`