### PR TITLE
Add the functionality to run jobs at specified intervals on specific dates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,8 @@ Usage
     schedule.every().wednesday.at("13:15").do(job)
     schedule.every().day.at("12:42", "Europe/Amsterdam").do(job)
     schedule.every().minute.at(":17").do(job)
+    schedule.every().date("05").do(job)
+    schedule.every().date("12/05").at("09:00").do(job)
 
     def job_with_argument(name):
         print(f"I am {name}")

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -43,6 +43,18 @@ Run a job every x minute
     schedule.every().wednesday.at("13:15").do(job)
     schedule.every().minute.at(":17").do(job)
 
+    # Run jobs every month on the 15th
+    schedule.every().date("15").do(job)
+
+    # Run jobs every 3 months at 12:34 on the 20th
+    schedule.every(3).date("20").at("12:34").do(job)
+
+    # Run jobs every year on the July 15th
+    schedule.every().date("07/15").do(job)
+
+    # Run jobs every 3 years at 11:11 on the August 25th
+    schedule.every(3).date("08/25").at("11:11").do(job)
+
     while True:
         schedule.run_pending()
         time.sleep(1)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,8 @@ Python job scheduling for humans. Run Python functions (or any other callable) p
     schedule.every().wednesday.at("13:15").do(job)
     schedule.every().day.at("12:42", "Europe/Amsterdam").do(job)
     schedule.every().minute.at(":17").do(job)
+    schedule.every().date("05").do(job)
+    schedule.every().date("12/05").at("09:00").do(job)
 
     while True:
         schedule.run_pending()

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -384,6 +384,74 @@ class SchedulerTests(unittest.TestCase):
             assert job.next_run.month == 11
             assert job.next_run.day == 25
 
+    def test_on_date(self):
+        with mock_datetime(2023, 10, 10, 10, 10):
+            mock_job = make_mock_job()
+            # Unit is `months`
+            assert every().date("09").do(mock_job).next_run.year == 2023
+            assert every().date("09").do(mock_job).next_run.month == 11
+            assert every().date("09").do(mock_job).next_run.day == 9
+            assert every().date("11").do(mock_job).next_run.year == 2023
+            assert every().date("11").do(mock_job).next_run.month == 10
+            assert every().date("11").do(mock_job).next_run.day == 11
+            assert every(3).date("09").do(mock_job).next_run.year == 2024
+            assert every(3).date("09").do(mock_job).next_run.month == 1
+            assert every(3).date("09").do(mock_job).next_run.day == 9
+            assert every(3).date("11").do(mock_job).next_run.year == 2023
+            assert every(3).date("11").do(mock_job).next_run.month == 10
+            assert every(3).date("11").do(mock_job).next_run.day == 11
+
+            # Unit is `years`
+            assert every().date("10/09").do(mock_job).next_run.year == 2024
+            assert every().date("10/09").do(mock_job).next_run.month == 10
+            assert every().date("10/09").do(mock_job).next_run.day == 9
+            assert every().date("10/11").do(mock_job).next_run.year == 2023
+            assert every().date("10/11").do(mock_job).next_run.month == 10
+            assert every().date("10/11").do(mock_job).next_run.day == 11
+            assert every(3).date("10/09").do(mock_job).next_run.year == 2026
+            assert every(3).date("10/09").do(mock_job).next_run.month == 10
+            assert every(3).date("10/09").do(mock_job).next_run.day == 9
+            assert every(3).date("10/11").do(mock_job).next_run.year == 2023
+            assert every(3).date("10/11").do(mock_job).next_run.month == 10
+            assert every(3).date("10/11").do(mock_job).next_run.day == 11
+
+            with self.assertRaises(ScheduleValueError):
+                every().date("09").seconds.do(mock_job)
+                every().date("09").minutes.do(mock_job)
+                every().date("09").hours.do(mock_job)
+                every().date("09").days.do(mock_job)
+                every().date("09").weeks.do(mock_job)
+
+            self.assertRaises(ScheduleValueError, every().second.date, "09")
+            self.assertRaises(ScheduleValueError, every().minute.date, "09")
+            self.assertRaises(ScheduleValueError, every().hour.date, "09")
+            self.assertRaises(ScheduleValueError, every().day.date, "09")
+            self.assertRaises(ScheduleValueError, every().week.date, "09")
+            self.assertRaises(ScheduleValueError, every().date, "1/09")
+            self.assertRaises(ScheduleValueError, every().date, "01/9")
+            self.assertRaises(ScheduleValueError, every().date, "00/09")
+            self.assertRaises(ScheduleValueError, every().date, "13/09")
+            self.assertRaises(ScheduleValueError, every().date, "01/00")
+            self.assertRaises(ScheduleValueError, every().date, "01/32")
+            self.assertRaises(ScheduleValueError, every().date, "01-09")
+            self.assertRaises(ScheduleValueError, every().date, "9")
+            self.assertRaises(ScheduleValueError, every().date, "00")
+            self.assertRaises(ScheduleValueError, every().date, "32")
+            self.assertRaises(TypeError, every().date, 9)
+
+    def test_on_date_repr(self):
+        mock_job = make_mock_job()
+
+        with mock_datetime(2023, 10, 10, 10, 10):
+            job_repr = repr(every(3).date("11").do(mock_job))
+            assert job_repr.startswith("Every 3 months on 11 do job()")
+            job_repr = repr(every(3).date("01/11").do(mock_job))
+            assert job_repr.startswith("Every 3 years on 1/11 do job()")
+            job_repr = repr(every(3).date("11").at("10:00:00").do(mock_job))
+            assert job_repr.startswith("Every 3 months on 11 at 10:00:00 do job()")
+            job_repr = repr(every(3).date("01/11").at("10:00:00").do(mock_job))
+            assert job_repr.startswith("Every 3 years on 1/11 at 10:00:00 do job()")
+
     def test_at_time_hour(self):
         with mock_datetime(2010, 1, 6, 12, 20):
             mock_job = make_mock_job()


### PR DESCRIPTION
resolve #487 

This PR will implement the feature discussed in the above issue.

To summarize this issue

- The functionality to schedule on a monthly or yearly unit is needed.
- Considering the job persistence that @gabrielcipriano points out, we should not simply add the functionality to schedule on a monthly or yearly unit.
- In light of these considerations, it is desirable to design the system to allow scheduling on a monthly or yearly unit as long as the specific dates are specified, which is the idea of @ttamg.

Therefore, I have implemented the feature that allows scheduling on a monthly or yearly unit by specifying a specific date.

This feature can be used as follows

```python
# Run jobs on the 5th of each month.
schedule.every().date("05").do(job)
# Run jobs at 9:00 on Dec 5th every two years.
schedule.every(2).date("12/05").at("09:00").do(job)
```

Your review and comments would be greatly appreciated.