### PR TITLE
Fix the issues that cause the build to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Python job scheduling for humans. Run Python functions (or any other callable) p
 - In-process scheduler for periodic jobs. No extra processes needed!
 - Very lightweight and no external dependencies.
 - Excellent test coverage.
-- Tested on Python and 3.6, 3.7, 3.8, 3.9
+- Tested on Python and 3.7, 3.8, 3.9, 3.10
 
 Usage
 -----

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ Python job scheduling for humans. Run Python functions (or any other callable) p
 - In-process scheduler for periodic jobs. No extra processes needed!
 - Very lightweight and no external dependencies.
 - Excellent test coverage.
-- Tested on Python 3.6, 3.7, 3.8 and 3.9
+- Tested on Python 3.7, 3.8, 3.9 and 3.10
 
 
 :doc:`Example <examples>`

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,7 +6,7 @@ Python version support
 ######################
 
 We recommend using the latest version of Python.
-Schedule is tested on Python 3.6, 3.7, 3.8 and 3.9
+Schedule is tested on Python 3.7, 3.8, 3.9 and 3.10
 
 Want to use Schedule on Python 2.7 or 3.5? Use version 0.6.0.
 

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -15,7 +15,7 @@ Features:
     - A simple to use API for scheduling jobs.
     - Very lightweight and no external dependencies.
     - Excellent test coverage.
-    - Tested on Python 3.6, 3.7, 3.8, 3.9
+    - Tested on Python 3.7, 3.8, 3.9, 3.10
 
 Usage:
     >>> import schedule

--- a/setup.py
+++ b/setup.py
@@ -43,11 +43,11 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Natural Language :: English",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
-envlist = py3{6,7,8,9}{,-pytz}
+envlist = py3{7,8,9,10}{,-pytz}
 skip_missing_interpreters = true
 
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [testenv]
 deps =


### PR DESCRIPTION
fix #560

This problem is the cause of build failures all the time.

This is a problem due to the ubuntu version changing from 20.04 to 22.04 when `ubuntu-latest` is specified in the github actions. The details are in #560 , but since the ubuntu version is now 22.04, python 3.6 is no longer available and builds will fail. python 3.6 has already reached EOL, so I would suggest including 3.10 in the target instead.
(Another solution would be to use `ubuntu-20.04` instead of `ubuntu-latest`.)

I would appreciate your review and comments.

(This PR is a split of PR #562, which was a mix of two issues.)