### PR TITLE
Fix bug where `Job.__repr__()` thows exception on partially composed job object

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+Unreleased
+++++++++++
+
+- Fix: Job __repr__ throws AttributeError when job_func is None.  See #485.
+
+
 1.1.0 (2021-04-09)
 ++++++++++++++++++
 

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -277,6 +277,10 @@ class Job(object):
         )
 
     def __repr__(self):
+        # If the Job is not yet fully composed, we cannot generate a pretty repr for it
+        if not self.job_func:
+            return str(self)
+
         def format_time(t):
             return t.strftime("%Y-%m-%d %H:%M:%S") if t else "[never]"
 

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -897,3 +897,10 @@ class SchedulerTests(unittest.TestCase):
         scheduler.every()
         scheduler.every(10).seconds
         scheduler.run_pending()
+
+    def test_repr_partial_job(self) -> None:
+        """
+        Ensure Job.__repr__ does not throw exception on a partially-composed Job
+        """
+        job = schedule.every(10)
+        repr(job)  # Used to throw exception due to Issue https://github.com/dbader/schedule/issues/485


### PR DESCRIPTION
Fix bug where `Job.__repr__()` thows exception on partially composed job.  

* Closes #485 