### PR TITLE
Remove a line duplicate from examples.rst

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -41,7 +41,6 @@ Run a job every x minute
     # Run job on a specific day of the week
     schedule.every().monday.do(job)
     schedule.every().wednesday.at("13:15").do(job)
-    schedule.every().minute.at(":17").do(job)
 
     while True:
         schedule.run_pending()


### PR DESCRIPTION
This line duplicates line 27 and does not relate to specific days of the week.