### PR TITLE
Using self.next_run.time() instead of self.at_time when "making sure we run at the specified time *today*"

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -761,7 +761,7 @@ class Job:
                 # Applying timezone to at_time as well so that checks with it stay consistent.
                 # Datetime is needed for using pytz library.
                 at_time_datetime = datetime.datetime.combine(
-                    datetime.date(2000, 1, 1),  # Arbitrary date
+                    self.next_run.date(),
                     self.at_time
                 )
                 at_time_datetime = (

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -757,20 +757,6 @@ class Job:
                     .astimezone()
                     .replace(tzinfo=None)
                 )
-                
-                # Applying timezone to at_time as well so that checks with it stay consistent.
-                # Datetime is needed for using pytz library to make conversions date-specific
-                # in cases of, for example, daylight savings.
-                # at_time_datetime = datetime.datetime.combine(
-                #     self.next_run.date(),
-                #     self.at_time
-                # )
-                # at_time_datetime = (
-                #     self.at_time_zone.localize(at_time_datetime)
-                #     .astimezone()
-                #     .replace(tzinfo=None)
-                # )
-                # self.at_time = at_time_datetime.time()
 
             # Make sure we run at the specified time *today* (or *this hour*)
             # as well. This accounts for when a job takes so long it finished

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -757,6 +757,19 @@ class Job:
                     .astimezone()
                     .replace(tzinfo=None)
                 )
+                
+                # Changing at_time so checks with it stay consistent.
+                # Datetime is needed for using pytz library.
+                at_time_datetime = datetime.datetime.combine(
+                    datetime.date(2000, 1, 1),  # Arbitrary date
+                    self.at_time
+                )
+                at_time_datetime = (
+                    self.at_time_zone.localize(at_time_datetime)
+                    .astimezone()
+                    .replace(tzinfo=None)
+                )
+                self.at_time = at_time_datetime.time()
 
             # Make sure we run at the specified time *today* (or *this hour*)
             # as well. This accounts for when a job takes so long it finished

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -761,16 +761,16 @@ class Job:
                 # Applying timezone to at_time as well so that checks with it stay consistent.
                 # Datetime is needed for using pytz library to make conversions date-specific
                 # in cases of, for example, daylight savings.
-                at_time_datetime = datetime.datetime.combine(
-                    self.next_run.date(),
-                    self.at_time
-                )
-                at_time_datetime = (
-                    self.at_time_zone.localize(at_time_datetime)
-                    .astimezone()
-                    .replace(tzinfo=None)
-                )
-                self.at_time = at_time_datetime.time()
+                # at_time_datetime = datetime.datetime.combine(
+                #     self.next_run.date(),
+                #     self.at_time
+                # )
+                # at_time_datetime = (
+                #     self.at_time_zone.localize(at_time_datetime)
+                #     .astimezone()
+                #     .replace(tzinfo=None)
+                # )
+                # self.at_time = at_time_datetime.time()
 
             # Make sure we run at the specified time *today* (or *this hour*)
             # as well. This accounts for when a job takes so long it finished
@@ -779,7 +779,7 @@ class Job:
                 now = datetime.datetime.now()
                 if (
                     self.unit == "days"
-                    and self.at_time > now.time()
+                    and self.next_run.time() > now.time()
                     and self.interval == 1
                 ):
                     self.next_run = self.next_run - datetime.timedelta(days=1)

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -758,7 +758,7 @@ class Job:
                     .replace(tzinfo=None)
                 )
                 
-                # Changing at_time so checks with it stay consistent.
+                # Applying timezone to at_time as well so that checks with it stay consistent.
                 # Datetime is needed for using pytz library.
                 at_time_datetime = datetime.datetime.combine(
                     datetime.date(2000, 1, 1),  # Arbitrary date

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -759,7 +759,8 @@ class Job:
                 )
                 
                 # Applying timezone to at_time as well so that checks with it stay consistent.
-                # Datetime is needed for using pytz library.
+                # Datetime is needed for using pytz library to make conversions date-specific
+                # in cases of, for example, daylight savings.
                 at_time_datetime = datetime.datetime.combine(
                     self.next_run.date(),
                     self.at_time

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -567,7 +567,9 @@ class SchedulerTests(unittest.TestCase):
             # Expected idle seconds: 68400
             schedule.clear()
             every().day.at("11:00", "Asia/Krasnoyarsk").do(mock_job)
-            expected_delta = datetime.datetime(2022, 3, 21, 5, 0) - datetime.datetime.now()
+            expected_delta = (
+                datetime.datetime(2022, 3, 21, 5, 0) - datetime.datetime.now()
+            )
             assert schedule.idle_seconds() == expected_delta.total_seconds()
 
         with self.assertRaises(pytz.exceptions.UnknownTimeZoneError):

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -537,7 +537,18 @@ class SchedulerTests(unittest.TestCase):
             # Expected to run India time: feb-2 06:30
             # Next run Berlin time: feb-2 02:00
             next = every().day.at("06:30", "Asia/Kolkata").do(mock_job).next_run
+            assert next.day == 2
             assert next.hour == 2
+            assert next.minute == 0
+
+        with mock_datetime(2023, 4, 14, 4, 50):
+            # Current Berlin time: april-14 04:50 (local) (during daylight saving)
+            # Current US/Central time: april-13 21:50
+            # Expected to run US/Central time: april-14 00:00
+            # Next run Berlin time: april-14 07:00
+            next = every().day.at("00:00", "US/Central").do(mock_job).next_run
+            assert next.day == 14
+            assert next.hour == 7
             assert next.minute == 0
 
         with mock_datetime(2022, 4, 8, 10, 0):

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -572,7 +572,7 @@ class SchedulerTests(unittest.TestCase):
 
         with mock_datetime(2022, 3, 20, 10, 0):
             # Current Berlin time: 10:00 (local) (NOT during daylight saving)
-            # Current Krasnoyarsk time: 15:00
+            # Current Krasnoyarsk time: 16:00
             # Expected to run Krasnoyarsk time: mar-21 11:00
             # Next run Berlin time: mar-21 05:00
             # Expected idle seconds: 68400

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -536,32 +536,18 @@ class SchedulerTests(unittest.TestCase):
             # Current India time: feb-2 03:45
             # Expected to run India time: feb-2 06:30
             # Next run Berlin time: feb-2 02:00
-            job = every().day.at("06:30", "Asia/Kolkata").do(mock_job)
-            
-            next = job.next_run
+            next = every().day.at("06:30", "Asia/Kolkata").do(mock_job).next_run
             assert next.hour == 2
             assert next.minute == 0
-
-            expected_delta = datetime.datetime(2022, 2, 2, 2, 0) - datetime.datetime.now()
-            assert schedule.idle_seconds() == expected_delta.total_seconds()
-
-            schedule.cancel_job(job)
 
         with mock_datetime(2022, 4, 8, 10, 0):
             # Current Berlin time: 10:00 (local) (during daylight saving)
             # Current NY time: 04:00
             # Expected to run NY time: 10:30
             # Next run Berlin time: 16:30
-            job = every().day.at("10:30", "America/New_York").do(mock_job)
-
-            next = job.next_run
+            next = every().day.at("10:30", "America/New_York").do(mock_job).next_run
             assert next.hour == 16
             assert next.minute == 30
-
-            expected_delta = datetime.datetime(2022, 4, 8, 16, 30) - datetime.datetime.now()
-            assert schedule.idle_seconds() == expected_delta.total_seconds()
-
-            schedule.cancel_job(job)
 
         with mock_datetime(2022, 3, 20, 10, 0):
             # Current Berlin time: 10:00 (local) (NOT during daylight saving)
@@ -569,33 +555,20 @@ class SchedulerTests(unittest.TestCase):
             # Expected to run NY time: 10:30
             # Next run Berlin time: 15:30
             tz = pytz.timezone("America/New_York")
-            job = every().day.at("10:30", tz).do(mock_job)
-
-            next = job.next_run
+            next = every().day.at("10:30", tz).do(mock_job).next_run
             assert next.hour == 15
             assert next.minute == 30
-
-            expected_delta = datetime.datetime(2022, 3, 20, 15, 30) - datetime.datetime.now()
-            assert schedule.idle_seconds() == expected_delta.total_seconds()
-
-            schedule.cancel_job(job)
 
         with mock_datetime(2022, 3, 20, 10, 0):
             # Current Berlin time: 10:00 (local) (NOT during daylight saving)
             # Current Krasnoyarsk time: 15:00
             # Expected to run Krasnoyarsk time: mar-21 11:00
             # Next run Berlin time: mar-21 05:00
-            tz = pytz.timezone("Asia/Krasnoyarsk")
-            job = every().day.at("11:00", tz).do(mock_job)
-
-            next = job.next_run
-            assert next.hour == 5
-            assert next.minute == 0
-
+            # Expected idle seconds: 68400
+            schedule.clear()
+            every().day.at("11:00", "Asia/Krasnoyarsk").do(mock_job)
             expected_delta = datetime.datetime(2022, 3, 21, 5, 0) - datetime.datetime.now()
             assert schedule.idle_seconds() == expected_delta.total_seconds()
-
-            schedule.cancel_job(job)
 
         with self.assertRaises(pytz.exceptions.UnknownTimeZoneError):
             every().day.at("10:30", "FakeZone").do(mock_job)

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -584,7 +584,7 @@ class SchedulerTests(unittest.TestCase):
             # Current Berlin time: 10:00 (local) (NOT during daylight saving)
             # Current Krasnoyarsk time: 15:00
             # Expected to run Krasnoyarsk time: mar-21 11:00
-            # Next run Berlin time: mar-21 06:00
+            # Next run Berlin time: mar-21 05:00
             tz = pytz.timezone("Asia/Krasnoyarsk")
             job = every().day.at("11:00", tz).do(mock_job)
 


### PR DESCRIPTION
An if-statement that subtracts a day from self.next_run was using self.at_time (a value not affected by timezone).
Thus, when applying timezone to self.next_run a day was incorrectly subtracted, like in https://github.com/dbader/schedule/issues/582#issue-1685602671 or, on the opposite, not subtracted, like in https://github.com/dbader/schedule/issues/579#issue-1667441469.
Tests for these issues are added as well.