### PR TITLE
change_func() method in jobs

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -698,6 +698,21 @@ class Job:
             logger.debug("Cancelling job %s", self)
             return CancelJob
         return ret
+    
+    def change_func(self, job_func, *args, **kwargs):
+        """
+        Change the job's function that's called every time the
+        job runs.
+
+        Any additional arguments are passed on to job_func when
+        the job runs.
+
+        :param job_func: The function to replace the old one
+        :return: The invoked job instance
+        """
+        self.job_func = functools.partial(job_func, *args, **kwargs)
+        functools.update_wrapper(self.job_func, job_func)
+        return self
 
     def _schedule_next_run(self) -> None:
         """


### PR DESCRIPTION
So, I created this exciting method, `job().change_func()`, because I think it would be cool to allow the users to change the job's function in a more implicit way, and, it also helps to keep the function metadata. Take a look:

```py
def hello(name):
    print(f'Hello, {name}!')

sch = schedule.every().second.do(hello, 'folks')

while True:
    if timer >= 10:
        sch.change_func(hello, 'friends') # Right here
        
    schedule.run_pending()
```

But what do you guys think? Sorry for anything, it's my first time contributing :)