### PR TITLE
Fix docs: added pytz as dependency when working with timezones

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,9 +14,9 @@ Want to use Schedule on earlier Python versions? See the History.
 Dependencies
 ############
 
-Schedule has no dependencies. None. Zero. Nada. Nopes.
-We plan to keep it that way.
+Schedule has 1 optional dependency:
 
+Only when you use ``.at()`` with a timezone, you must have `pytz <https://pypi.org/project/pytz/>`_ installed.
 
 Installation instructions
 #########################


### PR DESCRIPTION
As pointed out in #586, the docs should reflect pytz as a dependency.