### PR TITLE
Improved timezones handling in next_run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,12 @@ jobs:
       max-parallel: 6
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-        pytz: ['', '-pytz']
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}${{ matrix.pytz }}
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}${{ matrix.pytz }}
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: pip install tox tox-gh-actions
       - name: Tests
@@ -29,7 +28,7 @@ jobs:
       - name: Coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: python-${{ matrix.python-version }}${{ matrix.pytz }}
+          COVERALLS_FLAG_NAME: python-${{ matrix.python-version }}
           COVERALLS_PARALLEL: true
         run: |
           pip3 install coveralls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,13 @@ jobs:
       max-parallel: 6
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        pytz: ['', '-pytz']
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}${{ matrix.pytz }}
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}${{ matrix.pytz }}
       - name: Install dependencies
         run: pip install tox tox-gh-actions
       - name: Tests
@@ -28,7 +29,7 @@ jobs:
       - name: Coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: python-${{ matrix.python-version }}
+          COVERALLS_FLAG_NAME: python-${{ matrix.python-version }}${{ matrix.pytz }}
           COVERALLS_PARALLEL: true
         run: |
           pip3 install coveralls

--- a/docs/timezones.rst
+++ b/docs/timezones.rst
@@ -29,18 +29,30 @@ This causes the ``next_run`` and ``last_run`` to always be in Pythons local time
 
 Daylight Saving Time
 ~~~~~~~~~~~~~~~~~~~~
-When scheduling jobs with relative time (that is when not using ``.at()``), daylight saving time (DST) is **not** taken into account.
-A job that is set to run every 4 hours might execute after 3 realtime hours when DST goes into effect.
-This is because schedule is timezone-unaware for relative times.
+Scheduling jobs that do not specify a timezone do **not** take clock-changes into account.
+Timezone unaware jobs will use naive local times to calculate the next run.
+For example, a job that is set to run every 4 hours might execute after 3 realtime hours when DST goes into effect.
 
-However, when using ``.at()``, DST **is** handed correctly: the job will always run at (or close after) the set timestamp.
-A job scheduled during a moment that is skipped, the job will execute after the clock is moved.
-For example, a job is scheduled ``.at("02:30")``, clock moves from ``02:00`` to ``03:00``, the job will run at ``03:00``.
+But when passing a timezone to ``.at()``, DST **is** taken into account.
+The job will run at the specified time, even when the clock changes.
 
-Example
+Example clock moves forward:
+~~~~~~~
+A job is scheduled ``.at("02:30", "Europe/Berlin")``.
+When the clock moves from ``02:00`` to ``03:00``, the job will run once at ``03:30``.
+The day after it will return to normal and run at ``02:30``.
+
+Example clock moves backwards:
+~~~~~~~
+A job is scheduled ``.at("02:30", "Europe/Berlin")``.
+When the clock moves from ``02:00`` to ``03:00``, the job will run once at ``02:30``.
+It will run only at the first time the clock hits ``02:30``, but not the second time.
+The day after, it will return to normal and run at ``02:30``.
+
+Example scheduling across timezones
 ~~~~~~~
 Let's say we are in ``Europe/Berlin`` and local datetime is ``2022 march 20, 10:00:00``.
-At the moment daylight saving time is not in effect in Berlin (UTC+1).
+At this moment daylight saving time is not in effect in Berlin (UTC+1).
 
 We schedule a job to run every day at 10:30:00 in America/New_York.
 At this time, daylight saving time is in effect in New York (UTC-4).

--- a/docs/timezones.rst
+++ b/docs/timezones.rst
@@ -37,20 +37,20 @@ But when passing a timezone to ``.at()``, DST **is** taken into account.
 The job will run at the specified time, even when the clock changes.
 
 Example clock moves forward:
-~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 A job is scheduled ``.at("02:30", "Europe/Berlin")``.
 When the clock moves from ``02:00`` to ``03:00``, the job will run once at ``03:30``.
 The day after it will return to normal and run at ``02:30``.
 
 Example clock moves backwards:
-~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 A job is scheduled ``.at("02:30", "Europe/Berlin")``.
 When the clock moves from ``02:00`` to ``03:00``, the job will run once at ``02:30``.
 It will run only at the first time the clock hits ``02:30``, but not the second time.
 The day after, it will return to normal and run at ``02:30``.
 
 Example scheduling across timezones
-~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Let's say we are in ``Europe/Berlin`` and local datetime is ``2022 march 20, 10:00:00``.
 At this moment daylight saving time is not in effect in Berlin (UTC+1).
 

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -803,7 +803,7 @@ class Job:
         normalized = self.at_time_zone.normalize(input)
         return normalized.replace(day=input.day, hour=input.hour, minute=input.minute, second=input.second, microsecond=input.microsecond)
 
-    def _to_at_timezone(self, input: datetime.datetime) -> datetime.datetime:
+    def _to_at_timezone(self, input: Optional[datetime.datetime]) -> datetime.datetime:
         if self.at_time_zone is None or input is None:
             return input
         return input.astimezone(self.at_time_zone)

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -810,7 +810,9 @@ class Job:
             microsecond=input.microsecond,
         )
 
-    def _to_at_timezone(self, input: Optional[datetime.datetime]) -> Optional[datetime.datetime]:
+    def _to_at_timezone(
+        self, input: Optional[datetime.datetime]
+    ) -> Optional[datetime.datetime]:
         if self.at_time_zone is None or input is None:
             return input
         return input.astimezone(self.at_time_zone)

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -470,7 +470,6 @@ class Job:
         return self
 
     def at(self, time_str: str, tz: Optional[str] = None):
-
         """
         Specify a particular time that the job should be run at.
 
@@ -797,11 +796,19 @@ class Job:
     # Usually when normalization of a timestamp causes the timestamp to change,
     # it preserves the moment in time and changes the local timestamp.
     # This method applies pytz normalization but preserves the local timestamp, in fact changing the moment in time.
-    def _normalize_preserve_timestamp(self, input: datetime.datetime) -> datetime.datetime:
+    def _normalize_preserve_timestamp(
+        self, input: datetime.datetime
+    ) -> datetime.datetime:
         if self.at_time_zone is None or input is None:
             return input
         normalized = self.at_time_zone.normalize(input)
-        return normalized.replace(day=input.day, hour=input.hour, minute=input.minute, second=input.second, microsecond=input.microsecond)
+        return normalized.replace(
+            day=input.day,
+            hour=input.hour,
+            minute=input.minute,
+            second=input.second,
+            microsecond=input.microsecond,
+        )
 
     def _to_at_timezone(self, input: Optional[datetime.datetime]) -> datetime.datetime:
         if self.at_time_zone is None or input is None:

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -810,7 +810,7 @@ class Job:
             microsecond=input.microsecond,
         )
 
-    def _to_at_timezone(self, input: Optional[datetime.datetime]) -> datetime.datetime:
+    def _to_at_timezone(self, input: Optional[datetime.datetime]) -> Optional[datetime.datetime]:
         if self.at_time_zone is None or input is None:
             return input
         return input.astimezone(self.at_time_zone)

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -756,7 +756,7 @@ class Job:
 
             self.next_run = self.next_run.replace(**kwargs)  # type: ignore
 
-            if self.next_run.tzinfo:
+            if self.at_time_zone is not None:
                 # Sometimes when changing time we move into a different timezone (e.g. DST)
                 # To correct the timezone-element, we can 'normalize' the time.
                 self.next_run = self.at_time_zone.normalize(self.next_run)
@@ -792,7 +792,7 @@ class Job:
 
         # Calculations happen in the configured timezone, but to execute the schedule we
         # need to know the next_run time in the system time. So we convert back to naive local
-        if self.next_run.tzinfo:
+        if self.at_time_zone is not None:
             self.next_run = self.at_time_zone.normalize(self.next_run)
             self.next_run = self.next_run.astimezone().replace(tzinfo=None)
 

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -794,9 +794,11 @@ class Job:
             self.next_run = self.next_run.astimezone().replace(tzinfo=None)
 
     # Usually when normalization of a timestamp causes the timestamp to change,
-    # it preseves the moment in time and changes the local timestamp.
+    # it preserves the moment in time and changes the local timestamp.
     # This method applies pytz normalization but preserves the local timestamp, in fact changing the moment in time.
     def _normalize_preserve_timestamp(self, input: datetime.datetime) -> datetime.datetime:
+        if self.at_time_zone is None:
+            return input
         normalized = self.at_time_zone.normalize(input)
         return normalized.replace(day=input.day, hour=input.hour, minute=input.minute, second=input.second, microsecond=input.microsecond)
 

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -769,6 +769,20 @@ class SchedulerTests(unittest.TestCase):
             assert next.hour == 1
             assert next.minute == 0
 
+        with mock_datetime(2023, 9, 18, 10, 00, 0, TZ_AUCKLAND):
+            schedule.clear()
+            # Testing issue #605
+            # Current time: Monday 18 September 10:00 NZST
+            # Current time UTC: Sunday 17 September 22:00
+            # We expect the job to run at 23:00 on Sunday 17 September NZST
+            # That is an expected idle time of 1 hour
+            # Expected next run in NZST: 2023-09-18 11:00:00
+            next = schedule.every().day.at("23:00", "UTC").do(mock_job).next_run
+            assert round(schedule.idle_seconds() / 3600) == 1
+            assert next.day == 18
+            assert next.hour == 11
+            assert next.minute == 0
+
         with self.assertRaises(pytz.exceptions.UnknownTimeZoneError):
             every().day.at("10:30", "FakeZone").do(mock_job)
 

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -549,7 +549,6 @@ class SchedulerTests(unittest.TestCase):
             assert job.next_run.hour == 14
             assert job.next_run.minute == 10 + offsetMinutes
 
-
     def test_next_run_time_minute_end(self):
         self.tst_next_run_time_minute_end(None)
 
@@ -769,9 +768,6 @@ class SchedulerTests(unittest.TestCase):
             assert next.day == 29
             assert next.hour == 1
             assert next.minute == 0
-
-
-
 
         with self.assertRaises(pytz.exceptions.UnknownTimeZoneError):
             every().day.at("10:30", "FakeZone").do(mock_job)

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -644,6 +644,17 @@ class SchedulerTests(unittest.TestCase):
             assert next.minute == 00
             assert next.second == 20
 
+        with mock_datetime(2023, 10, 22, 23, 0, 0, TZ_UTC):
+            # Current UTC: sunday 23:00
+            # Current Amsterdam: monday 01:00 (daylight saving active)
+            # Expected run Amsterdam: sunday 29 oktober 23:00 (daylight saving NOT active)
+            # Next run UTC time: oktober-29 22:00
+            schedule.clear()
+            next = every().sunday.at("23:00", "Europe/Amsterdam").do(mock_job).next_run
+            assert next.day == 29
+            assert next.hour == 22
+            assert next.minute == 00
+
         with self.assertRaises(pytz.exceptions.UnknownTimeZoneError):
             every().day.at("10:30", "FakeZone").do(mock_job)
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,15 @@ skip_missing_interpreters = true
 [gh-actions]
 python =
     3.7: py37
+    3.7-pytz: py37-pytz
     3.8: py38
+    3.8-pytz: py38-pytz
     3.9: py39
+    3.9-pytz: py39-pytz
     3.10: py310
+    3.10-pytz: py310-pytz
     3.11: py311
+    3.11-pytz: py311-pytz
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -5,16 +5,11 @@ skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.7: py37
-    3.7-pytz: py37-pytz
-    3.8: py38
-    3.8-pytz: py38-pytz
-    3.9: py39
-    3.9-pytz: py39-pytz
-    3.10: py310
-    3.10-pytz: py310-pytz
-    3.11: py311
-    3.11-pytz: py311-pytz
+    3.7: py37, py37-pytz
+    3.8: py38, py38-pytz
+    3.9: py39, py39-pytz
+    3.10: py310, py310-pytz
+    3.11: py311, py311-pytz
 
 [testenv]
 deps =


### PR DESCRIPTION
This improves how the timezone configured in `.at("18:00", "Europe/Amsterdam")` is processed.

The problem is that the `self.next_run value` is localized to `self.at_time_zone` and then converted to local time. In the next condition, the code uses `datetime.datetime.now()`, which fetches the current time in the local timezone. If the system's local timezone is different from `self.at_time_zone`, this can result in a discrepancy and cause the computation of self.next_run to be off by a day or more. This is what is happening in #603.

This PR changes the timezone-handling approach to use localized datetimes throughout the whole `_schedule_next_run` function.

PR created as draft since there are still a few untested cases that I would like to add tests for before merging. Especially in the area of combining `.at()` with weekdays, `until()` and daylight-saving-time. 

