### PR TITLE
remove dependency on old mock

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 docutils
-mock
 Pygments
 pytest
 pytest-cov

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -1,7 +1,7 @@
 """Unit tests for schedule.py"""
 import datetime
 import functools
-import mock
+from unittest import mock
 import unittest
 import os
 import time

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ python =
 
 [testenv]
 deps =
-    mock
     pytest
     pytest-cov
     mypy


### PR DESCRIPTION
https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.