### PR TITLE
Timezone bugfixes

### DIFF
--- a/docs/timezones.rst
+++ b/docs/timezones.rst
@@ -38,9 +38,14 @@ The job will run at the specified time, even when the clock changes.
 
 Example clock moves forward:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When a job is scheduled in the gap that occurs when the clock moves forward, the job is scheduled after the gap.
+
 A job is scheduled ``.at("02:30", "Europe/Berlin")``.
 When the clock moves from ``02:00`` to ``03:00``, the job will run once at ``03:30``.
 The day after it will return to normal and run at ``02:30``.
+
+A job is scheduled ``.at("01:00", "Europe/London")``.
+When the clock moves from ``01:00`` to ``02:00``, the job will run once at ``02:00``.
 
 Example clock moves backwards:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -724,7 +724,7 @@ class Job:
             next_run = self._move_to_next_weekday(next_run, self.start_day)
 
         if self.at_time is not None:
-            next_run = self._move_to_time(next_run, self.at_time)
+            next_run = self._move_to_time(next_run)
 
         period = datetime.timedelta(**{self.unit: interval})
         if interval != 1:
@@ -772,16 +772,17 @@ class Job:
             )
         return weekdays.index(day)
 
-    def _move_to_time(
-        self, moment: datetime.datetime, time: datetime.time
-    ) -> datetime.datetime:
-        kwargs = {"second": time.second, "microsecond": 0}
+    def _move_to_time(self, moment: datetime.datetime) -> datetime.datetime:
+        if self.at_time is None:
+            return moment
+
+        kwargs = {"second": self.at_time.second, "microsecond": 0}
 
         if self.unit == "days" or self.start_day is not None:
-            kwargs["hour"] = time.hour
+            kwargs["hour"] = self.at_time.hour
 
         if self.unit in ["days", "hours"] or self.start_day is not None:
-            kwargs["minute"] = time.minute
+            kwargs["minute"] = self.at_time.minute
 
         moment = moment.replace(**kwargs)  # type: ignore
 
@@ -819,7 +820,6 @@ class Job:
 
         # Adjust the time to reset the date-time to have the same HH:mm components
         moment -= offset_diff
-
 
         # Check if moving the timestamp back by the utc-offset-difference made it end up
         # in a moment that does not exist within the current timezone/utc-offset

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -706,7 +706,6 @@ class Job:
                 "Invalid unit (valid units are `seconds`, `minutes`, `hours`, "
                 "`days`, and `weeks`)"
             )
-        print("---")
         if self.latest is not None:
             if not (self.latest >= self.interval):
                 raise ScheduleError("`latest` is greater than `interval`")
@@ -734,18 +733,11 @@ class Job:
 
         while next_run <= now:
             next_run += period
-            # if self.at_time_zone is not None:
-            #     next_run = self.at_time_zone.normalize(next_run)
-
-
-        print("pre-magic ", next_run.strftime(fmt))
 
         # To keep the api consistent with older versions, we have to set the 'next_run' to a naive timestamp in the local timezone.
         # Because we want to stay backwards compatible with older versions.
         if self.at_time_zone is not None:
             next_run = next_run.astimezone()
-
-            print("post-magic ", next_run.strftime(fmt))
 
             # The local utc-offset might change between the current time and the next_run (Daylight Saving Time).
             # Thus, the next_run must be localized to the utc-offset *at the time of the next_run*.
@@ -800,10 +792,8 @@ class Job:
 
         moment = moment.replace(**kwargs)  # type: ignore
 
-        print("before", moment.strftime(fmt))
         if self.at_time_zone is not None:
             flag = self._get_dst_flag(moment)
-            print(flag)
 
             # When we set the time elements, we might end up in a different offset than the current offset.
             # This happens when we cross into or out of daylight saving time.

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -44,7 +44,7 @@ import logging
 import random
 import re
 import time
-from typing import Set, List, Optional, Callable, Union, Literal
+from typing import Set, List, Optional, Callable, Union
 
 logger = logging.getLogger("schedule")
 
@@ -828,7 +828,7 @@ class Job:
 
         return moment
 
-    def _get_dst_flag(self, timestamp: datetime.datetime) -> Literal["NONE", "FOLD", "GAP"]:
+    def _get_dst_flag(self, timestamp: datetime.datetime) -> str:
         """
         Figure out if the timestamp is in a DST gap, fold or none of them.
         Returns 'FOLD' if the timestamp is the second occurrence of a moment where the clock is moved back.

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -47,7 +47,6 @@ import time
 from typing import Set, List, Optional, Callable, Union, Literal
 
 logger = logging.getLogger("schedule")
-fmt = '%Y-%m-%d %H:%M:%S %Z (%z)'
 
 
 class ScheduleError(Exception):

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -796,38 +796,41 @@ class Job:
     ) -> datetime.datetime:
         if self.at_time_zone is None:
             return moment
-        # Normalize adjusts the timezone to the correct offset at the given
-        # moment while keeping the moment in time the same.
+        # Normalize corrects the utc-offset to match the timezone
+        # For example: When a date&time&offset does not exist within a timezone,
+        # the normalization will change the utc-offset to where it is valid.
+        # It does this while keeping the moment in time the same, by moving the
+        # time component opposite of the utc-change.
         offset_before_normalize = moment.utcoffset()
         moment = self.at_time_zone.normalize(moment)
         offset_after_normalize = moment.utcoffset()
 
         if offset_before_normalize == offset_after_normalize:
-            # There was no change in the utc-offset, so we don't need to do anything.
+            # There was no change in the utc-offset, datetime didn't change.
             return moment
+
+        # The utc-offset and time-component has changed
 
         if not fixate_time:
-            # The time has changed, but we don't need to fixate the time to the new offset.
+            # No need to fixate the time.
             return moment
 
-        # There can be two cases in which we reach this point:
-        #   - Fold: The same timestamp happens twice, and the timestamp is in the second occurrence.
-        #           The normalization moved the timestamp to the correct timezone, thereby increasing the local time.
-        #   - Gap: The local time did not exist.
-        #          The normalization moved the timestamp forward by the amount that is the difference between utc-offsets.
-        # In either case, the timestamp was moved forward by the difference in utc-offsets.
-        # We correct this:
-        moment = moment - (offset_after_normalize - offset_before_normalize)
+        offset_diff = offset_after_normalize - offset_before_normalize
 
-        # Check if moving the timestamp back by the utc-offset made it end up at
+        # Adjust the time to reset the date-time to have the same HH:mm components
+        moment -= offset_diff
+
+
+        # Check if moving the timestamp back by the utc-offset-difference made it end up
         # in a moment that does not exist within the current timezone/utc-offset
-        if self.at_time_zone.normalize(moment).utcoffset() == offset_before_normalize:
+        re_normalized_offset = self.at_time_zone.normalize(moment).utcoffset()
+        if re_normalized_offset != offset_after_normalize:
             # We ended up in a DST Gap. The requested 'at' time does not exist
             # within the current timezone/utc-offset. As a best effort, we will
             # schedule the job 1 offset later than possible.
             # For example, if 02:23 does not exist (because DST moves from 02:00
             # to 03:00), this will schedule the job at 03:23.
-            moment = moment + (offset_after_normalize - offset_before_normalize)
+            moment += offset_diff
         return moment
 
     def _is_overdue(self, when: datetime.datetime):

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -921,15 +921,3 @@ def repeat(job, *args, **kwargs):
 
     return _schedule_decorator
 
-def _datetime_exists(dattim: datetime.datetime) -> bool:
-    """Check if a datetime exists."""
-    assert dattim.tzinfo is not None
-    original_tzinfo = dattim.tzinfo
-    # Check if we can round trip to UTC
-    return dattim == dattim.astimezone(datetime.UTC).astimezone(original_tzinfo)
-
-def _datetime_ambiguous(dattim: datetime.datetime) -> bool:
-    """Check whether a datetime is ambiguous."""
-    assert dattim.tzinfo is not None
-    opposite_fold = dattim.replace(fold=not dattim.fold)
-    return _datetime_exists(dattim) and dattim.utcoffset() != opposite_fold.utcoffset()

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -919,6 +919,7 @@ def _move_to_next_weekday(moment: datetime.datetime, weekday: str):
         days_ahead += 7
     return moment + datetime.timedelta(days=days_ahead)
 
+
 def _weekday_index(day: str) -> int:
     weekdays = (
         "monday",

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -831,10 +831,12 @@ class Job:
     def _get_dst_flag(self, timestamp: datetime.datetime) -> Literal["NONE", "FOLD", "GAP"]:
         """
         Figure out if the timestamp is in a DST gap, fold or none of them.
-        Thanks to https://stackoverflow.com/a/77310437/2328729
+        Returns 'FOLD' if the timestamp is the second occurrence of a moment where the clock is moved back.
+        Returns 'GAP if the timstamp is during a moment where the clock is moved forward,
+        or if the timestamp is the first occurrence of a moment, where the second occurance would return 'FOLD'.
         """
         u = timestamp.utcoffset()
-        v = self.at_time_zone.normalize(timestamp.replace(fold=not timestamp.fold)).utcoffset()
+        v = timestamp.tzinfo.normalize(timestamp.replace(fold=not timestamp.fold)).utcoffset()
         if u == v:
             return "NONE"
         if (u < v) == timestamp.fold:

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -633,6 +633,40 @@ class SchedulerTests(unittest.TestCase):
             assert next.hour == 15
             assert next.minute == 30
 
+        # Test the DST-case that is described in the documentation
+        with mock_datetime(2023, 3, 26, 1, 30):
+            # Current Berlin time: 01:30 (NOT during daylight saving)
+            # Expected to run: 02:30 - this time doesn't exist
+            #  because clock moves from 02:00 to 03:00
+            # Next run: 03:30
+            job = every().day.at("02:30", "Europe/Berlin").do(mock_job)
+            assert job.next_run.day == 26
+            assert job.next_run.hour == 3
+            assert job.next_run.minute == 30
+        with mock_datetime(2023, 3, 27, 1, 30):
+            # the next day the job shall again run at 02:30
+            job.run()
+            assert job.next_run.day == 27
+            assert job.next_run.hour == 2
+            assert job.next_run.minute == 30
+
+        # Test the DST-case that is described in the documentation
+        with mock_datetime(2023, 10, 29, 1, 30):
+            # Current Berlin time: 01:30 (during daylight saving)
+            # Expected to run: 02:30 - this time exists twice
+            #  because clock moves from 03:00 to 02:00
+            # Next run should be at the first occurrence of 02:30
+            job = every().day.at("02:30", "Europe/Berlin").do(mock_job)
+            assert job.next_run.day == 29
+            assert job.next_run.hour == 2
+            assert job.next_run.minute == 30
+        with mock_datetime(2023, 10, 29, 2, 35):
+            # After the job runs, the next run should be scheduled on the next day at 02:30
+            job.run()
+            assert job.next_run.day == 30
+            assert job.next_run.hour == 2
+            assert job.next_run.minute == 30
+
         with mock_datetime(2022, 3, 20, 10, 0):
             # Current Berlin time: 10:00 (local) (NOT during daylight saving)
             # Current Krasnoyarsk time: 16:00
@@ -835,40 +869,6 @@ class SchedulerTests(unittest.TestCase):
             assert next.hour == 12
             assert next.minute == 0
 
-        # Test the DST-case that is described in the documentation
-        with mock_datetime(2023, 3, 26, 1, 30):
-            # Current Berlin time: 01:30 (NOT during daylight saving)
-            # Expected to run: 02:30 - this time doesn't exist
-            #  because clock moves from 02:00 to 03:00
-            # Next run: 03:30
-            job = every().day.at("02:30", "Europe/Berlin").do(mock_job)
-            assert job.next_run.day == 26
-            assert job.next_run.hour == 3
-            assert job.next_run.minute == 30
-        with mock_datetime(2023, 3, 27, 1, 30):
-            # the next day the job shall again run at 02:30
-            job.run()
-            assert job.next_run.day == 27
-            assert job.next_run.hour == 2
-            assert job.next_run.minute == 30
-
-        # Test the DST-case that is described in the documentation
-        with mock_datetime(2023, 10, 29, 1, 30):
-            # Current Berlin time: 01:30 (during daylight saving)
-            # Expected to run: 02:30 - this time exists twice
-            #  because clock moves from 03:00 to 02:00
-            # Next run should be at the first occurrence of 02:30
-            job = every().day.at("02:30", "Europe/Berlin").do(mock_job)
-            assert job.next_run.day == 29
-            assert job.next_run.hour == 2
-            assert job.next_run.minute == 30
-        with mock_datetime(2023, 10, 29, 2, 35):
-            # After the job runs, the next run should be scheduled on the next day at 02:30
-            job.run()
-            assert job.next_run.day == 30
-            assert job.next_run.hour == 2
-            assert job.next_run.minute == 30
-
         with self.assertRaises(pytz.exceptions.UnknownTimeZoneError):
             every().day.at("10:30", "FakeZone").do(mock_job)
 
@@ -1042,7 +1042,7 @@ class SchedulerTests(unittest.TestCase):
     def test_run_every_weekday_at_specific_time_today(self):
         mock_job = make_mock_job()
         with mock_datetime(2010, 1, 6, 13, 16): # january 6 2010 == Wednesday
-            print(every().wednesday.at("14:12").do(mock_job).next_run)
+            every().wednesday.at("14:12").do(mock_job)
             schedule.run_pending()
             assert mock_job.call_count == 0
 

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -1244,6 +1244,28 @@ class SchedulerTests(unittest.TestCase):
         with mock_datetime(2022, 10, 30, 0, 0):
             assert every(4).hours.do(mock_job).next_run.hour == 4
 
+    def test_move_to_next_weekday_today(self):
+        monday = datetime.datetime(2024, 5, 13, 10, 27, 54)
+        tuesday = schedule._move_to_next_weekday(monday, "monday")
+        assert tuesday.day == 13 # today! Time didn't change.
+        assert tuesday.hour == 10
+        assert tuesday.minute == 27
+
+    def test_move_to_next_weekday_tommorrow(self):
+        monday = datetime.datetime(2024, 5, 13, 10, 27, 54)
+        tuesday = schedule._move_to_next_weekday(monday, "tuesday")
+        assert tuesday.day == 14 # 1 day ahead
+        assert tuesday.hour == 10
+        assert tuesday.minute == 27
+
+    def test_move_to_next_weekday_nextweek(self):
+        wednesday = datetime.datetime(2024, 5, 15, 10, 27, 54)
+        tuesday = schedule._move_to_next_weekday(wednesday, "tuesday")
+        assert tuesday.day == 21 # next week monday
+        assert tuesday.hour == 10
+        assert tuesday.minute == 27
+
+
     def test_run_all(self):
         mock_job = make_mock_job()
         every().minute.do(mock_job)

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -1164,7 +1164,11 @@ class SchedulerTests(TestCase):
             import pytz
         except ModuleNotFoundError:
             self.skipTest("pytz unavailable")
-        job = schedule.every().day.at("10:00", "Europe/Berlin").do(make_mock_job("tz-test"))
+        job = (
+            schedule.every()
+            .day.at("10:00", "Europe/Berlin")
+            .do(make_mock_job("tz-test"))
+        )
         tz = pytz.timezone("Europe/Berlin")
         return (job, tz)
 
@@ -1198,7 +1202,9 @@ class SchedulerTests(TestCase):
         (job, tz) = self.setup_utc_offset_test()
         # This time exists twice, this is the 1st occurance
         overlap_time = tz.localize(datetime.datetime(2024, 10, 27, 1, 30), is_dst=True)
-        overlap_time += datetime.timedelta(hours=1)  # puts it at 02:30+02:00 (Which exists once)
+        overlap_time += datetime.timedelta(
+            hours=1
+        )  # puts it at 02:30+02:00 (Which exists once)
 
         aligned_time = job._align_utc_offset(overlap_time, fixate_time=True)
         # The time should not have moved, because the original time is valid
@@ -1246,24 +1252,23 @@ class SchedulerTests(TestCase):
     def test_move_to_next_weekday_today(self):
         monday = datetime.datetime(2024, 5, 13, 10, 27, 54)
         tuesday = schedule._move_to_next_weekday(monday, "monday")
-        assert tuesday.day == 13 # today! Time didn't change.
+        assert tuesday.day == 13  # today! Time didn't change.
         assert tuesday.hour == 10
         assert tuesday.minute == 27
 
     def test_move_to_next_weekday_tommorrow(self):
         monday = datetime.datetime(2024, 5, 13, 10, 27, 54)
         tuesday = schedule._move_to_next_weekday(monday, "tuesday")
-        assert tuesday.day == 14 # 1 day ahead
+        assert tuesday.day == 14  # 1 day ahead
         assert tuesday.hour == 10
         assert tuesday.minute == 27
 
     def test_move_to_next_weekday_nextweek(self):
         wednesday = datetime.datetime(2024, 5, 15, 10, 27, 54)
         tuesday = schedule._move_to_next_weekday(wednesday, "tuesday")
-        assert tuesday.day == 21 # next week monday
+        assert tuesday.day == 21  # next week monday
         assert tuesday.hour == 10
         assert tuesday.minute == 27
-
 
     def test_run_all(self):
         mock_job = make_mock_job()

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -1347,19 +1347,19 @@ class SchedulerTests(unittest.TestCase):
         gap = datetime.datetime(2024, 9, 8, 0, 30, 0,
                                 tzinfo=pytz.timezone("America/Santiago"))
 
-        assert job._get_dst_flag(gap) == "GAP"
+        assert job._get_dst_flag(gap.tzinfo, gap) == "GAP"
 
         # When America/Santiago time is about to reach
         # Sunday, 7 April 2024, 00:00:00 clocks were turned backward 1 hour to
         # Saturday, 6 April 2024, 23:00:00 local standard time instead.
         fold0 = datetime.datetime(2024, 4, 6, 23, 30, 0,
                                 tzinfo=pytz.timezone("America/Santiago"), fold=0)
-        assert job._get_dst_flag(fold0) == "GAP"
+        assert job._get_dst_flag(fold0.tzinfo, fold0) == "GAP"
         fold1 = datetime.datetime(2024, 4, 6, 23, 30, 0,
                                 tzinfo=pytz.timezone("America/Santiago"), fold=1)
-        assert job._get_dst_flag(fold1) == "FOLD"
+        assert job._get_dst_flag(fold1.tzinfo, fold1) == "FOLD"
 
         # Test a timezone that doesn't have DST
         no_dst = datetime.datetime(2024, 4, 6, 23, 30, 0,
                                    tzinfo=pytz.timezone("UTC"))
-        assert job._get_dst_flag(no_dst) == "NONE"
+        assert job._get_dst_flag(no_dst.tzinfo, no_dst) == "NONE"

--- a/test_schedule.py
+++ b/test_schedule.py
@@ -1,4 +1,5 @@
 """Unit tests for schedule.py"""
+
 import datetime
 import functools
 import mock
@@ -34,6 +35,7 @@ def make_mock_job(name=None):
     job = mock.Mock()
     job.__name__ = name or "job"
     return job
+
 
 class mock_datetime:
     """
@@ -618,7 +620,6 @@ class SchedulerTests(unittest.TestCase):
             assert next.hour == 7
             assert next.minute == 0
 
-
     def test_tz_daily_half_hour_offset(self):
         mock_job = self.make_tz_mock_job()
         with mock_datetime(2022, 4, 8, 10, 0):
@@ -630,10 +631,10 @@ class SchedulerTests(unittest.TestCase):
             assert next.hour == 16
             assert next.minute == 30
 
-
     def test_tz_daily_dst(self):
         mock_job = self.make_tz_mock_job()
         import pytz
+
         with mock_datetime(2022, 3, 20, 10, 0):
             # Current Berlin time: 10:00 (local) (NOT during daylight saving)
             # Current NY time: 04:00 (during daylight saving)
@@ -643,7 +644,6 @@ class SchedulerTests(unittest.TestCase):
             next = every().day.at("10:30", tz).do(mock_job).next_run
             assert next.hour == 15
             assert next.minute == 30
-
 
     def test_tz_daily_dst_skip_hour(self):
         mock_job = self.make_tz_mock_job()
@@ -664,7 +664,6 @@ class SchedulerTests(unittest.TestCase):
             assert job.next_run.hour == 2
             assert job.next_run.minute == 30
 
-
     def test_tz_daily_dst_overlap_hour(self):
         mock_job = self.make_tz_mock_job()
         # Test the DST-case that is described in the documentation
@@ -684,7 +683,6 @@ class SchedulerTests(unittest.TestCase):
             assert job.next_run.hour == 2
             assert job.next_run.minute == 30
 
-
     def test_tz_daily_exact_future_scheduling(self):
         mock_job = self.make_tz_mock_job()
         with mock_datetime(2022, 3, 20, 10, 0):
@@ -699,7 +697,6 @@ class SchedulerTests(unittest.TestCase):
                 datetime.datetime(2022, 3, 21, 5, 0) - datetime.datetime.now()
             )
             assert schedule.idle_seconds() == expected_delta.total_seconds()
-
 
     def test_tz_daily_utc(self):
         mock_job = self.make_tz_mock_job()
@@ -722,7 +719,6 @@ class SchedulerTests(unittest.TestCase):
             assert next.hour == 12
             assert next.minute == 0
 
-
     def test_tz_daily_issue_592(self):
         mock_job = self.make_tz_mock_job()
         with mock_datetime(2023, 7, 15, 13, 0, 0, TZ_UTC):
@@ -735,7 +731,6 @@ class SchedulerTests(unittest.TestCase):
             assert next.day == 15
             assert next.hour == 13
             assert next.minute == 45
-
 
     def test_tz_daily_exact_seconds_precision(self):
         mock_job = self.make_tz_mock_job()
@@ -751,7 +746,6 @@ class SchedulerTests(unittest.TestCase):
             assert next.hour == 22
             assert next.minute == 00
             assert next.second == 20
-
 
     def test_tz_weekly_sunday_conversion(self):
         mock_job = self.make_tz_mock_job()
@@ -804,7 +798,6 @@ class SchedulerTests(unittest.TestCase):
             assert next.hour == 0
             assert next.minute == 0
 
-
     def test_tz_daily_leap_year(self):
         mock_job = self.make_tz_mock_job()
         with mock_datetime(2024, 2, 28, 23, 50):
@@ -849,7 +842,6 @@ class SchedulerTests(unittest.TestCase):
             assert next.day == 26
             assert next.hour == 3
             assert next.minute == 0
-
 
     def test_tz_daily_dst_ending_point(self):
         mock_job = self.make_tz_mock_job()
@@ -931,7 +923,12 @@ class SchedulerTests(unittest.TestCase):
             # Exected next run in Newfoundland: 4 may, 09:14:45
             # Expected next run in Chatham: 5 may, 00:29:45
             schedule.clear()
-            next = schedule.every(10).hours.at("14:45", "Canada/Newfoundland").do(mock_job).next_run
+            next = (
+                schedule.every(10)
+                .hours.at("14:45", "Canada/Newfoundland")
+                .do(mock_job)
+                .next_run
+            )
             assert next.day == 5
             assert next.hour == 0
             assert next.minute == 29
@@ -980,7 +977,7 @@ class SchedulerTests(unittest.TestCase):
             # Expected time: 3 Nov, 02:43:13 Chatham
             assert job.next_run.day == 3
             assert job.next_run.hour == 2
-            assert job.next_run.minute == 43 # Within the fold, first occurrence
+            assert job.next_run.minute == 43  # Within the fold, first occurrence
             assert job.next_run.second == 13
         with mock_datetime(2024, 11, 3, 2, 23, 55, TZ_CHATHAM, fold=1):
             # Time is during the fold. Local time has moved back 1 hour, this is
@@ -1052,7 +1049,12 @@ class SchedulerTests(unittest.TestCase):
         with mock_datetime(2024, 3, 28, 11, 0, 0, TZ_BERLIN):
             # At March 31st 2024, 02:00:00 clocks were turned forward 1 hour
             schedule.clear()
-            next = schedule.every(7).days.at("11:00", "Europe/Berlin").do(mock_job).next_run
+            next = (
+                schedule.every(7)
+                .days.at("11:00", "Europe/Berlin")
+                .do(mock_job)
+                .next_run
+            )
             assert next.month == 4
             assert next.day == 4
             assert next.hour == 11
@@ -1062,11 +1064,17 @@ class SchedulerTests(unittest.TestCase):
     def test_tz_weekly_large_interval_backward(self):
         mock_job = self.make_tz_mock_job()
         import pytz
+
         # Testing scheduling large intervals that skip over clock move back
         with mock_datetime(2024, 10, 25, 11, 0, 0, TZ_BERLIN):
             # At March 31st 2024, 02:00:00 clocks were turned forward 1 hour
             schedule.clear()
-            next = schedule.every(7).days.at("11:00", "Europe/Berlin").do(mock_job).next_run
+            next = (
+                schedule.every(7)
+                .days.at("11:00", "Europe/Berlin")
+                .do(mock_job)
+                .next_run
+            )
             assert next.month == 11
             assert next.day == 1
             assert next.hour == 11
@@ -1083,7 +1091,12 @@ class SchedulerTests(unittest.TestCase):
             # Expected time Anchorage: 3 Nov, 14:00 (UTC-09:00)
             # Expected time Berlin:    4 Nov, 00:00
             schedule.clear()
-            next = schedule.every().day.at("14:00", "America/Anchorage").do(mock_job).next_run
+            next = (
+                schedule.every()
+                .day.at("14:00", "America/Anchorage")
+                .do(mock_job)
+                .next_run
+            )
             assert next.day == 4
             assert next.hour == 0
             assert next.minute == 00
@@ -1103,7 +1116,9 @@ class SchedulerTests(unittest.TestCase):
             # Expected time Berlin:       31 Mar, 10:00 (UTC+02:00)
             # Expected time Berlin Extra: 31 Mar, 11:00 (UTC+03:00)
             schedule.clear()
-            next = schedule.every().day.at("10:00", "Europe/Berlin").do(mock_job).next_run
+            next = (
+                schedule.every().day.at("10:00", "Europe/Berlin").do(mock_job).next_run
+            )
             assert next.day == 31
             assert next.hour == 11
             assert next.minute == 00
@@ -1122,7 +1137,9 @@ class SchedulerTests(unittest.TestCase):
             # Expected time Berlin:          31 Mar, 10:00 (UTC+02:00) +9 hour
             # Expected time Berlin Inverted: 31 Mar, 09:00 (UTC+01:00)
             schedule.clear()
-            next = schedule.every().day.at("10:00", "Europe/Berlin").do(mock_job).next_run
+            next = (
+                schedule.every().day.at("10:00", "Europe/Berlin").do(mock_job).next_run
+            )
             assert next.day == 31
             assert next.hour == 9
             assert next.minute == 00
@@ -1303,7 +1320,7 @@ class SchedulerTests(unittest.TestCase):
 
     def test_run_every_weekday_at_specific_time_today(self):
         mock_job = make_mock_job()
-        with mock_datetime(2010, 1, 6, 13, 16): # january 6 2010 == Wednesday
+        with mock_datetime(2010, 1, 6, 13, 16):  # january 6 2010 == Wednesday
             every().wednesday.at("14:12").do(mock_job)
             schedule.run_pending()
             assert mock_job.call_count == 0


### PR DESCRIPTION
Cross-timezone scheduling was broken. This is an attempt to fix that. To make sure this actually works in all cases, I've added a bunch of unit tests based on edge cases and reported issues. Furthermore I've split up the code a bit more to make it easier to understand and document. In this process I discovered more weird edge cases, which are now described as test cases. 

Resolves #608 and #609 and #605 and  #603

Everyone is invited to take a look and find more bugs / untested edge cases. Suggestions are welcome! I will leave this PR open until Saturday, after which I will merge & make a new release. 

Todo:
- [x] Add tests from examples in #608
- [x] Add tests for exotic timezones
- [x] Add test that covers a full year of daylight saving time changes, both local timezone and remote timezone
- [x] Add test for schedules that skips over daylight saving time changes, both local and remote
- [x] Add tests for situations where both local and remote timezones experience daylight saving time changes between now and the next scheduled event
- [x] Add separate tests for `_move_to_next_weekday`
- [x] Add separate tests for `_align_utc_offset`