### PR TITLE
Don't call str() in logging calls that already use %s

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -154,10 +154,10 @@ class Scheduler:
         :param job: The job to be unscheduled
         """
         try:
-            logger.debug('Cancelling job "%s"', str(job))
+            logger.debug('Cancelling job "%s"', job)
             self.jobs.remove(job)
         except ValueError:
-            logger.debug('Cancelling not-scheduled job "%s"', str(job))
+            logger.debug('Cancelling not-scheduled job "%s"', job)
 
     def every(self, interval: int = 1) -> "Job":
         """


### PR DESCRIPTION
Small perf improvement when logging at that level (for that logger) isn't enabled