### PR TITLE
Function to add time to job

### DIFF
--- a/docs/background-execution.rst
+++ b/docs/background-execution.rst
@@ -7,51 +7,50 @@ This is an example of how you could do this:
 
 .. code-block:: python
 
-import threading
-import time
+    import threading
+    import time
 
-import schedule
-
-
-def run_continuously(interval=1):
-    """Continuously run, while executing pending jobs at each
-    elapsed time interval.
-    @return cease_continuous_run: threading. Event which can
-    be set to cease continuous run. Please note that it is
-    *intended behavior that run_continuously() does not run
-    missed jobs*. For example, if you've registered a job that
-    should run every minute and you set a continuous run
-    interval of one hour then your job won't be run 60 times
-    at each interval but only once.
-    """
-    cease_continuous_run = threading.Event()
-    class ScheduleThread(threading.Thread):
-        @classmethod
-        def run(cls):
-            while not cease_continuous_run.is_set():
-                schedule.run_pending()
-                time.sleep(interval)
-    continuous_thread = ScheduleThread()
-    continuous_thread.start()
-    return cease_continuous_run
+    import schedule
 
 
-def background_job():
-    print('Hello from the background thread')
+    def run_continuously(interval=1):
+        """Continuously run, while executing pending jobs at each
+        elapsed time interval.
+        @return cease_continuous_run: threading. Event which can
+        be set to cease continuous run. Please note that it is
+        *intended behavior that run_continuously() does not run
+        missed jobs*. For example, if you've registered a job that
+        should run every minute and you set a continuous run
+        interval of one hour then your job won't be run 60 times
+        at each interval but only once.
+        """
+        cease_continuous_run = threading.Event()
+
+        class ScheduleThread(threading.Thread):
+            @classmethod
+            def run(cls):
+                while not cease_continuous_run.is_set():
+                    schedule.run_pending()
+                    time.sleep(interval)
+
+        continuous_thread = ScheduleThread()
+        continuous_thread.start()
+        return cease_continuous_run
 
 
-schedule.every(30).seconds.do(background_job)
+    def background_job():
+        print('Hello from the background thread')
 
-# Start the background thread
-stop_run_continuously = run_continuously()
-all_jobs = schedule.get_jobs()
 
-a = all_jobs[0]
+    schedule.every().second.do(background_job)
 
-# Do some other things...
-time.sleep(10)
+    # Start the background thread
+    stop_run_continuously = run_continuously()
 
-# Stop the background thread
-stop_run_continuously.set()
+    # Do some other things...
+    time.sleep(10)
+
+    # Stop the background thread
+    stop_run_continuously.set()
 
 

--- a/docs/background-execution.rst
+++ b/docs/background-execution.rst
@@ -7,50 +7,51 @@ This is an example of how you could do this:
 
 .. code-block:: python
 
-    import threading
-    import time
+import threading
+import time
 
-    import schedule
-
-
-    def run_continuously(interval=1):
-        """Continuously run, while executing pending jobs at each
-        elapsed time interval.
-        @return cease_continuous_run: threading. Event which can
-        be set to cease continuous run. Please note that it is
-        *intended behavior that run_continuously() does not run
-        missed jobs*. For example, if you've registered a job that
-        should run every minute and you set a continuous run
-        interval of one hour then your job won't be run 60 times
-        at each interval but only once.
-        """
-        cease_continuous_run = threading.Event()
-
-        class ScheduleThread(threading.Thread):
-            @classmethod
-            def run(cls):
-                while not cease_continuous_run.is_set():
-                    schedule.run_pending()
-                    time.sleep(interval)
-
-        continuous_thread = ScheduleThread()
-        continuous_thread.start()
-        return cease_continuous_run
+import schedule
 
 
-    def background_job():
-        print('Hello from the background thread')
+def run_continuously(interval=1):
+    """Continuously run, while executing pending jobs at each
+    elapsed time interval.
+    @return cease_continuous_run: threading. Event which can
+    be set to cease continuous run. Please note that it is
+    *intended behavior that run_continuously() does not run
+    missed jobs*. For example, if you've registered a job that
+    should run every minute and you set a continuous run
+    interval of one hour then your job won't be run 60 times
+    at each interval but only once.
+    """
+    cease_continuous_run = threading.Event()
+    class ScheduleThread(threading.Thread):
+        @classmethod
+        def run(cls):
+            while not cease_continuous_run.is_set():
+                schedule.run_pending()
+                time.sleep(interval)
+    continuous_thread = ScheduleThread()
+    continuous_thread.start()
+    return cease_continuous_run
 
 
-    schedule.every().second.do(background_job)
+def background_job():
+    print('Hello from the background thread')
 
-    # Start the background thread
-    stop_run_continuously = run_continuously()
 
-    # Do some other things...
-    time.sleep(10)
+schedule.every(30).seconds.do(background_job)
 
-    # Stop the background thread
-    stop_run_continuously.set()
+# Start the background thread
+stop_run_continuously = run_continuously()
+all_jobs = schedule.get_jobs()
+
+a = all_jobs[0]
+
+# Do some other things...
+time.sleep(10)
+
+# Stop the background thread
+stop_run_continuously.set()
 
 

--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -663,6 +663,13 @@ class Job:
         self.scheduler.jobs.append(self)
         return self
 
+    def add_time_to_next_run(self, seconds=0, minutes=0, hours=0, days=0, weeks=0, months=0, years=0):
+        """
+        function to add time to the next_run of a job and ONLY the next run
+        """
+        time_in_seconds = seconds + (minutes * 60) + (hours * 3600) + (days * 86400) + (weeks * 604800) + (months * 259200) + (years * 31536000)
+        self.next_run = self.next_run + datetime.timedelta(seconds=time_in_seconds)
+
     @property
     def should_run(self) -> bool:
         """


### PR DESCRIPTION
Added a function which accepts a time arg which modifies the next_run value.
useful in that you can iterate through the schedule and add extra time to an existing job without having to delve into datetime madness 